### PR TITLE
Adapts URLs for badges and CI after renaming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ The HERE Data SDK for TypeScript is a TypeScript client for the <a href="https:/
 
 | Master                      | Node version       | Status                                                                                                                                                                                       |
 | :-------------------------- | :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Build/Test/Bundling/Typedoc | Node 12.13.0 (LTS) | <a href="https://travis-ci.com/heremaps/here-olp-sdk-typescript" target="_blank"><img src="https://travis-ci.com/heremaps/here-olp-sdk-typescript.svg?branch=master" alt="Build Status"></a> |
+| Build/Test/Bundling/Typedoc | Node 12.13.0 (LTS) | <a href="https://travis-ci.com/heremaps/here-data-sdk-typescript" target="_blank"><img src="https://travis-ci.com/heremaps/here-data-sdk-typescript.svg?branch=master" alt="Build Status"></a> |
 
 ### Test Coverage
 
-<a href="https://codecov.io/gh/heremaps/here-olp-sdk-typescript/" target="_blank"><img src="https://codecov.io/gh/heremaps/here-olp-sdk-typescript/branch/master/graph/badge.svg" alt="Linux code coverage"/></a>
+| Platform | Status                                                                                                                                                                                              |
+| :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Linux    | <a href="https://codecov.io/gh/heremaps/here-data-sdk-typescript/" target="_blank"><img src="https://codecov.io/gh/heremaps/here-data-sdk-typescript/branch/master/graph/badge.svg" alt="Linux code coverage"/></a> |
 
 ## Why Use
 
@@ -36,13 +38,13 @@ For more information on Data API, see its <a href="https://developer.here.com/ol
 
 When new API is introduced in the Data SDK for TypeScript, the old one is not deleted straight away. The standard API deprecation time is 6 months. It gives you time to switch to new code. However, we do not provide ABI backward compatibility.
 
-All of the deprecated methods, functions, and parameters are documented in the Data SDK for TypeScript <a href="https://developer.here.com/olp/documentation/sdk-typescript/api_reference/index.html"  target="_blank">API Reference</a> and <a href="https://github.com/heremaps/here-olp-sdk-typescript/blob/master/CHANGELOG.md" target="_blank">changelog</a>.
+All of the deprecated methods, functions, and parameters are documented in the Data SDK for TypeScript <a href="https://developer.here.com/olp/documentation/sdk-typescript/api_reference/index.html"  target="_blank">API Reference</a> and <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/CHANGELOG.md" target="_blank">changelog</a>.
 
 ## About This Repository
 
 The HERE Data SDK for TypeScript repository is a monorepo that contains the core components of the platform SDK organized in the NPM workspace.
 
-All components can be used stand-alone and are in the <a href="https://github.com/heremaps/here-olp-sdk-typescript/tree/master/%40here" target="_blank">@here</a> subdirectory.
+All components can be used stand-alone and are in the <a href="https://github.com/heremaps/here-data-sdk-typescript/tree/master/%40here" target="_blank">@here</a> subdirectory.
 
 ## Installation
 
@@ -65,7 +67,7 @@ https://unpkg.com/@here/olp-sdk-dataservice-read/bundle.umd.min.js
 https://unpkg.com/@here/olp-sdk-fetch/bundle.umd.min.js
 ```
 
-To learn how to use the Data SDK for TypeScript, see the <a href="https://github.com/heremaps/here-olp-sdk-typescript/blob/master/docs/GettingStartedGuide.md" target="_blank">Getting Started Guide</a>.
+To learn how to use the Data SDK for TypeScript, see the <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/docs/GettingStartedGuide.md" target="_blank">Getting Started Guide</a>.
 
 ## Development
 
@@ -163,4 +165,4 @@ npm run bundle
 
 Copyright (C) 2019–2020 HERE Europe B.V.
 
-For license details, see the <a href="https://github.com/heremaps/here-olp-sdk-typescript/blob/master/LICENSE" target="_blank">LICENSE</a> file in the root of this project.
+For license details, see the <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/LICENSE" target="_blank">LICENSE</a> file in the root of this project.


### PR DESCRIPTION
This commit adapts all necessary URLs for internal links, CI and
badges from third party providers after renaming of the repository
to the new official name HERE Data SDK for TypeScript.

Relates-To: OLPEDGE-1889

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>