### PR TITLE
Fixing failed h4web e2e test.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
@@ -138,7 +138,15 @@ export class CatalogClient {
             }
             requestedCatalogVersion = await this.getLatestVersion(
                 catalogVersionRequest
-            ).catch(async error => Promise.reject(error));
+            ).catch(error => Promise.reject(error));
+        }
+
+        if (requestedCatalogVersion === undefined) {
+            return Promise.reject(
+                new Error(
+                    "Please set version with LayerVersionsRequest.withVersion() method."
+                )
+            );
         }
 
         const layerVersions = await MetadataApi.getLayerVersions(builder, {


### PR DESCRIPTION
Test was failing on compilation time with error:

"CatalogClient.ts:145:13 - error TS2322: Type 'number | undefined'
is not assignable to type 'number'. version: requestedCatalogVersion,
in  node_modules/@here/olp-sdk-dataservice-api/lib/metadata-api.ts:273:15
params: { version: number; billingTag?: string }".

Adding extra check fixes that.

Resolves: OLPEDGE-1977

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>