### PR TITLE
Adding VersionedLayerClient dummy class.

### DIFF
--- a/@here/olp-sdk-dataservice-write/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/VersionedLayerClient.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { HRN, OlpClientSettings } from "@here/olp-sdk-core";
+
+/**
+ * Parameters for use to initialize VolatileLayerClient.
+ */
+export interface VersionedLayerClientParams {
+    // [[HRN]] instance of the catalog hrn.
+    catalogHrn: HRN;
+    // The [[OlpClientSettings]] instance.
+    settings: OlpClientSettings;
+}
+
+/**
+ * Describes a versioned layer and provides the possibility to push the data to the versioned layers.
+ */
+export class VersionedLayerClient {
+    /**
+     * Creates the [[VersionedLayerClient]] instance with VersionedLayerClientParams.
+     *
+     * @param params parameters for use to initialize VersionedLayerClient.
+     */
+    constructor(private readonly params: VersionedLayerClientParams) {}
+}

--- a/@here/olp-sdk-dataservice-write/lib/client/index.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/index.ts
@@ -17,4 +17,4 @@
  * License-Filename: LICENSE
  */
 
-export class HelloWorld {}
+export * from "./VersionedLayerClient";

--- a/@here/olp-sdk-dataservice-write/lib/index.ts
+++ b/@here/olp-sdk-dataservice-write/lib/index.ts
@@ -17,4 +17,4 @@
  * License-Filename: LICENSE
  */
 
-export * from "./HelloWorld";
+export * from "./client";

--- a/@here/olp-sdk-dataservice-write/package.json
+++ b/@here/olp-sdk-dataservice-write/package.json
@@ -50,6 +50,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@here/olp-sdk-core": "1.0.0",
     "@here/olp-sdk-fetch": "1.4.0"
   },
   "devDependencies": {

--- a/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
@@ -20,18 +20,29 @@
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
-import { HelloWorld } from "../../lib";
+import { VersionedLayerClient } from "@here/olp-sdk-dataservice-write";
 
 chai.use(sinonChai);
 
 const assert = chai.assert;
 const expect = chai.expect;
+class MockedHrn {
+    constructor(private readonly hrn: string) {}
+    toString(): string {
+        return this.hrn;
+    }
+}
 
-describe("HelloWorld", () => {
+describe("VersionedLayerClient write", () => {
     it("Should initialize", () => {
-        const hello = new HelloWorld();
+        const catalogHrn = "hrn:here:data:::mocked-hrn";
 
-        assert.isDefined(hello);
-        expect(hello).be.instanceOf(HelloWorld);
+        const client = new VersionedLayerClient({
+            catalogHrn: new MockedHrn(catalogHrn) as any,
+            settings: {} as any
+        });
+
+        assert.isDefined(client);
+        expect(client).be.instanceOf(VersionedLayerClient);
     });
 });

--- a/tests/integration/mocha.opts
+++ b/tests/integration/mocha.opts
@@ -4,4 +4,4 @@
 --bail
 --check-leaks
 --reporter xunit
-tests/integration/*.test.ts
+tests/integration/olp-sdk-*/*.test.ts

--- a/tests/integration/olp-sdk-dataservice-read/ArtifactClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/ArtifactClient.test.ts
@@ -27,7 +27,7 @@ import {
   SchemaDetailsRequest,
   HRN
 } from "@here/olp-sdk-dataservice-read";
-import { FetchMock } from "./FetchMock";
+import { FetchMock } from "../FetchMock";
 import { LIB_VERSION } from "@here/olp-sdk-dataservice-read/lib.version";
 import { HttpError } from "@here/olp-sdk-core";
 

--- a/tests/integration/olp-sdk-dataservice-read/CatalogClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/CatalogClient.test.ts
@@ -28,8 +28,8 @@ import {
   CatalogRequest,
   LayerVersionsRequest
 } from "@here/olp-sdk-dataservice-read";
-import { FetchMock } from "./FetchMock";
-import { LIB_VERSION } from "@here/olp-sdk-dataservice-read/lib.version";
+import { FetchMock } from "../FetchMock";
+import { LIB_VERSION } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 

--- a/tests/integration/olp-sdk-dataservice-read/ConfigClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/ConfigClient.test.ts
@@ -28,9 +28,9 @@ import {
   HRN,
   CatalogsRequest
 } from "@here/olp-sdk-dataservice-read";
-import { FetchMock } from "./FetchMock";
+import { FetchMock } from "../FetchMock";
 import { ConfigApi } from "@here/olp-sdk-dataservice-api";
-import { LIB_VERSION } from "@here/olp-sdk-dataservice-read/lib.version";
+import { LIB_VERSION } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 

--- a/tests/integration/olp-sdk-dataservice-read/Handling-versions.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/Handling-versions.test.ts
@@ -32,7 +32,7 @@ import {
   LayerVersionsRequest,
   CatalogVersionRequest
 } from "@here/olp-sdk-dataservice-read";
-import { FetchMock } from "./FetchMock";
+import { FetchMock } from "../FetchMock";
 
 chai.use(sinonChai);
 const expect = chai.expect;

--- a/tests/integration/olp-sdk-dataservice-read/IndexLayerClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/IndexLayerClient.test.ts
@@ -26,9 +26,9 @@ import {
   IndexLayerClient,
   IndexQueryRequest
 } from "@here/olp-sdk-dataservice-read";
-import { FetchMock } from "./FetchMock";
+import { FetchMock } from "../FetchMock";
 import { Buffer } from "buffer";
-import { LIB_VERSION } from "@here/olp-sdk-dataservice-read/lib.version";
+import { LIB_VERSION } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 

--- a/tests/integration/olp-sdk-dataservice-read/Metadata-api.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/Metadata-api.test.ts
@@ -26,7 +26,7 @@ import {
   RequestFactory
 } from "@here/olp-sdk-dataservice-read";
 import { MetadataApi } from "@here/olp-sdk-dataservice-api";
-import { FetchMock } from "./FetchMock";
+import { FetchMock } from "../FetchMock";
 
 chai.use(sinonChai);
 const expect = chai.expect;

--- a/tests/integration/olp-sdk-dataservice-read/StatisticsClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/StatisticsClient.test.ts
@@ -28,8 +28,8 @@ import {
   StatisticsRequest,
   CoverageDataType
 } from "@here/olp-sdk-dataservice-read";
-import { FetchMock } from "./FetchMock";
-import { LIB_VERSION } from "@here/olp-sdk-dataservice-read/lib.version";
+import { FetchMock } from "../FetchMock";
+import { LIB_VERSION } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 

--- a/tests/integration/olp-sdk-dataservice-read/StreamLayerClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/StreamLayerClient.test.ts
@@ -29,7 +29,7 @@ import {
   UnsubscribeRequest,
   SeekRequest
 } from "@here/olp-sdk-dataservice-read";
-import { FetchMock } from "./FetchMock";
+import { FetchMock } from "../FetchMock";
 import { Buffer } from "buffer";
 import { Message } from "@here/olp-sdk-dataservice-api/lib/stream-api";
 

--- a/tests/integration/olp-sdk-dataservice-write/VersionedLayer.test.ts
+++ b/tests/integration/olp-sdk-dataservice-write/VersionedLayer.test.ts
@@ -20,18 +20,25 @@
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
-import { HelloWorld } from "@here/olp-sdk-dataservice-write";
+import { VersionedLayerClient } from "@here/olp-sdk-dataservice-write";
+import { HRN, OlpClientSettings } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("HelloWorld", () => {
+describe("Versioned Layer Client for write", () => {
   it("Should initialize", () => {
-    const hello = new HelloWorld();
+    const hello = new VersionedLayerClient({
+      catalogHrn: HRN.fromString("hrn:here:data:::mocked-hrn"),
+      settings: new OlpClientSettings({
+        environment: "here",
+        getToken: () => Promise.resolve("mocked-token")
+      })
+    });
 
     assert.isDefined(hello);
-    expect(hello).be.instanceOf(HelloWorld);
+    expect(hello).be.instanceOf(VersionedLayerClient);
   });
 });


### PR DESCRIPTION
This CR adds new empty class for dataservice-write
and test for initialization.

Adds olp-sdk-core as a dependency. Removes dummy HelloWorld class.

Split integration tests. And use LIB_VERSION in test from core package.

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>