### PR TITLE
Add GetBaseVersion method.

### DIFF
--- a/tests/integration/olp-sdk-dataservice-write/VersionedLayer.test.ts
+++ b/tests/integration/olp-sdk-dataservice-write/VersionedLayer.test.ts
@@ -19,9 +19,11 @@
 
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
+import sinon = require("sinon");
 
 import { VersionedLayerClient } from "@here/olp-sdk-dataservice-write";
 import { HRN, OlpClientSettings } from "@here/olp-sdk-core";
+import { FetchMock } from "../FetchMock";
 
 chai.use(sinonChai);
 
@@ -29,16 +31,99 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 describe("Versioned Layer Client for write", () => {
+  let fetchMock: FetchMock;
+  let sandbox: sinon.SinonSandbox;
+  let fetchStub: sinon.SinonStub;
+  let settings: OlpClientSettings;
+
+  settings = new OlpClientSettings({
+    environment: "here",
+    getToken: () => Promise.resolve("mocked-token")
+  });
+  const catalogHrn = HRN.fromString("hrn:here:data:::mocked-hrn");
+
+  const headers = new Headers();
+  headers.append("cache-control", "max-age=3600");
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  beforeEach(() => {
+    fetchMock = new FetchMock();
+    fetchStub = sandbox.stub(global as any, "fetch");
+    fetchStub.callsFake(fetchMock.fetch());
+
+    settings = new OlpClientSettings({
+      environment: "here",
+      getToken: () => Promise.resolve("mocked-token")
+    });
+  });
+
   it("Should initialize", () => {
-    const hello = new VersionedLayerClient({
-      catalogHrn: HRN.fromString("hrn:here:data:::mocked-hrn"),
-      settings: new OlpClientSettings({
-        environment: "here",
-        getToken: () => Promise.resolve("mocked-token")
-      })
+    const client = new VersionedLayerClient({
+      catalogHrn,
+      settings
     });
 
-    assert.isDefined(hello);
-    expect(hello).be.instanceOf(VersionedLayerClient);
+    assert.isDefined(client);
+    expect(client).be.instanceOf(VersionedLayerClient);
+  });
+
+  xit("Should fetch the latest version of catalog", async () => {
+    const mockedResponses = new Map();
+
+    // Set the response from lookup api with the info about Metadata service.
+    mockedResponses.set(
+      `https://api-lookup.data.api.platform.here.com/lookup/v1/resources/hrn:here:data:::mocked-hrn/apis`,
+      new Response(
+        JSON.stringify([
+          {
+            api: "metadata",
+            version: "v1",
+            baseURL: "https://metadata.data.api.platform.here.com/metadata/v1",
+            parameters: {
+              additionalProp1: "string",
+              additionalProp2: "string",
+              additionalProp3: "string"
+            }
+          }
+        ]),
+        { headers }
+      )
+    );
+
+    const mockedVersion = {
+      version: 123
+    };
+
+    mockedResponses.set(
+      `https://metadata.data.api.platform.here.com/metadata/v1/versions/latest?startVersion=-1`,
+      new Response(JSON.stringify(mockedVersion), { headers })
+    );
+
+    // Setup the fetch to use mocked responses.
+    fetchMock.withMockedResponses(mockedResponses);
+
+    const client = new VersionedLayerClient({
+      catalogHrn,
+      settings
+    });
+    let versionResponse = await client.getBaseVersion();
+
+    assert.isDefined(versionResponse);
+
+    expect(versionResponse).to.be.equal(123);
+
+    /**
+     * Should be two calls:
+     *  1 - lookup
+     *  2 - metadata
+     */
+    expect(fetchStub.callCount).to.be.equal(2);
   });
 });


### PR DESCRIPTION
This CR adding the new method to the VersionedLayerClient write.
The method allows users to get the latest version of the catalog.

Resolves: OLPEDGE-1937

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>