### PR TITLE
SHA-256 to sign token requests, instead of SHA-1.

### DIFF
--- a/@here/olp-sdk-authentication/lib/requestToken.ts
+++ b/@here/olp-sdk-authentication/lib/requestToken.ts
@@ -21,7 +21,7 @@ import * as crypto from "crypto";
 import { OAuthArgs, requestToken_common, Token } from "./requestToken_common";
 
 async function sign(data: ArrayBufferLike, secretKey: string): Promise<string> {
-    const hmac = crypto.createHmac("sha1", secretKey);
+    const hmac = crypto.createHmac("sha256", secretKey);
     hmac.update(Buffer.from(data));
     return Promise.resolve(hmac.digest("base64"));
 }
@@ -32,7 +32,7 @@ function getRandomValues(data: Uint8Array): Uint8Array {
 
 /**
  * Creates an access token.
- * 
+ *
  * @param args The arguments needed to get the access token.
  * @return The generated access token.
  */

--- a/@here/olp-sdk-authentication/lib/requestToken.web.ts
+++ b/@here/olp-sdk-authentication/lib/requestToken.web.ts
@@ -48,7 +48,7 @@ async function sign(data: ArrayBufferLike, secretKey: string): Promise<string> {
         keyData,
         {
             name: "HMAC",
-            hash: { name: "SHA-1" }
+            hash: { name: "SHA-256" }
         },
         false,
         ["sign"]
@@ -70,7 +70,7 @@ function getRandomValues(data: Uint8Array): Uint8Array {
 
 /**
  * Creates an access token.
- * 
+ *
  * @param args The arguments needed to get the access token.
  * @return The generated access token.
  */

--- a/@here/olp-sdk-authentication/lib/requestToken_common.ts
+++ b/@here/olp-sdk-authentication/lib/requestToken_common.ts
@@ -116,7 +116,7 @@ async function getOAuthAuthorization(
         encodeURIComponent(args.url) +
         "&" +
         encodeURIComponent(
-            `oauth_consumer_key=${args.consumerKey}&oauth_nonce=${args.nonce}&oauth_signature_method=HMAC-SHA1&oauth_timestamp=${args.timestamp}&oauth_version=1.0`
+            `oauth_consumer_key=${args.consumerKey}&oauth_nonce=${args.nonce}&oauth_signature_method=HMAC-SHA256&oauth_timestamp=${args.timestamp}&oauth_version=1.0`
         );
 
     const signature = await signLatin1(
@@ -129,7 +129,7 @@ async function getOAuthAuthorization(
         args.consumerKey
     )}",oauth_nonce="${encodeURIComponent(
         args.nonce
-    )}",oauth_signature_method="HMAC-SHA1",oauth_timestamp="${
+    )}",oauth_signature_method="HMAC-SHA256",oauth_timestamp="${
         args.timestamp
     }",oauth_version="1.0",oauth_signature="${encodeURIComponent(signature)}"`;
 }

--- a/@here/olp-sdk-authentication/test/OAuth.test.ts
+++ b/@here/olp-sdk-authentication/test/OAuth.test.ts
@@ -76,6 +76,23 @@ describe("oauth-request-offline", () => {
         fetchMock.reset();
     });
 
+    // tslint:disable-next-line: only-arrow-functions
+    it("SHA-256 to sign token requests", async function() {
+        const result = await requestToken({
+            consumerKey: "mocked-key",
+            secretKey: "mocked-secret",
+            url: "https://account.api.here.com/oauth2/token",
+            nonce: "mocked-nonce",
+            scope: "mocked-scope",
+            timestamp: MOCK_CREATED_TIME
+        });
+
+        const options: RequestInit & any = fetchMock.calls()[0][1];
+        expect(options.headers.get("Authorization")).to.be.equal(
+            `OAuth oauth_consumer_key="mocked-key",oauth_nonce="mocked-nonce",oauth_signature_method="HMAC-SHA256",oauth_timestamp="1550777140",oauth_version="1.0",oauth_signature="67j%2FteHKLDlh%2F8VVMU3pRSyGN7lXtC49dkRtWCFoz6U%3D"`
+        );
+    });
+
     it("requestToken", async () => {
         const consumerKey = "key";
         const secretKey = "secret";


### PR DESCRIPTION
This CR change SHA-1 to SHA-256 to be used to sign token requests
SHA-1 is not the documented way and may result
in breakage once SHA-1 support is removed from the service.

Resolves: OLPEDGE-10758

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>