### PR TITLE
Add CheckDataExists method.

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/blob-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/blob-api.ts
@@ -229,6 +229,7 @@ export async function cancelMultipartUpload(
 }
 
 /**
+ * @deprecated This function will be deleted 12.20. Please use checkBlobExistsStatus.
  * Checks if a blob exists for the requested data handle.
  *
  * @summary Checks if a data handle exists
@@ -265,6 +266,42 @@ export async function checkBlobExists(
 }
 
 /**
+ * Checks if a blob exists for the requested data handle.
+ *
+ * @summary Checks if a data handle exists
+ * @param layerId The ID of the layer that the blob belongs to.
+ * @param dataHandle The data handle identifies a specific blob so that you can get that blob's contents.
+ * The data handle can only contain alphanumeric, "-" and "." characters, [0-9, a-z, A-Z, -, .].
+ * The maximum length of this field is 1024 characters.
+ * @param billingTag Billing Tag is an optional free-form tag which is used for grouping billing records together.
+ * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
+ * Grouping billing records by billing tag will be available in future releases.
+ */
+export async function checkBlobExistsStatus(
+    builder: RequestBuilder,
+    params: {
+        layerId: string;
+        dataHandle: string;
+        billingTag?: string;
+    }
+): Promise<Response> {
+    const baseUrl = "/layers/{layerId}/data/{dataHandle}"
+        .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
+        .replace("{dataHandle}", UrlBuilder.toString(params["dataHandle"]));
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+    urlBuilder.appendQuery("billingTag", params["billingTag"]);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "HEAD",
+        headers
+    };
+
+    return builder.requestBlob(urlBuilder, options);
+}
+
+/**
  * Call this API when all parts have been uploaded. Please keep in mind that the actual URL for this operation
  * must be obtained from the response body of start multipart operation that is
  * 'POST /layers/{layerId}/data/{dataHandle}/multiparts' from the 'complete' element under the top level 'links' element of the response.
@@ -272,7 +309,7 @@ export async function checkBlobExists(
  * @summary Completes a multipart upload
  * @param layerId The ID of the layer that the data blob part belongs to.
  * @param dataHandle The data handle (ID) represents an identifier for the data blob which the part
- * belongs to. The data handle can only contain alphanumeric, &#39;-&#39; and &#39;.&#39; characters,
+ * belongs to. The data handle can only contain alphanumeric, "-"; and "." characters,
  * [0-9, a-z, A-Z, -, .]. The maximum length of this field is 1024 characters.
  * @param multiPartToken The identifier of the multi part upload (token). Content of this parameter must
  * refer to a valid nand started multipart upload.
@@ -446,20 +483,24 @@ export async function getMultipartUploadStatus(
 }
 
 /**
- * Persists the data blob in the underlying storage mechanism (volume). Use this upload mechanism for blobs smaller than 50 MB.
- * The size limit for blobs uploaded this way is 5 GB but we do not recommend uploading blobs this large with this method, so use
- * multipart upload instead. When the operation completes successfully there is no guarantee that the data blob will be immediately
- * available although in most cases it will be. To check if the data blob is available use the HEAD method.
+ * Persists the data blob in the underlying storage mechanism (volume).
+ * Use this upload mechanism for blobs smaller than 50 MB.
+ * The size limit for blobs uploaded this way is 5 GB but we do not recommend uploading blobs
+ * this large with this method, so use multipart upload instead.
+ * When the operation completes successfully there is no guarantee that the data blob will be
+ * immediately available although in most cases it will be.
+ * To check if the data blob is available use the HEAD method.
  *
  * @summary Publishes a data blob
  * @param layerId The ID of the layer that the data blob belongs to.
- * @param dataHandle The data handle (ID) represents an identifier for the data blob. The data handle can only contain alphanumeric,
- * &#39;-&#39; and &#39;.&#39; characters, [0-9, a-z, A-Z, -, .]. The maximum length of this field is 1024 characters.
+ * @param dataHandle The data handle (ID) represents an identifier for the data blob.
+ * The data handle can only contain alphanumeric, &#39;-&#39; and &#39;.&#39; characters, [0-9, a-z, A-Z, -, .].
+ * The maximum length of this field is 1024 characters.
  * @param body body
- * @param contentLength Size of the entity-body, in bytes. For more information,
- * see [RFC 7230, section 3.3.2: Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2).
- * @param billingTag Billing Tag is an optional free-form tag which is used for grouping billing records
- * together. If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
+ * @param contentLength Size of the entity-body, in bytes.
+ * For more information, see [RFC 7230, section 3.3.2: Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2).
+ * @param billingTag Billing Tag is an optional free-form tag which is used for grouping billing records together.
+ * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
  * Grouping billing records by billing tag will be available in future releases.
  */
 export async function putBlob(

--- a/@here/olp-sdk-dataservice-api/test/BlobApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/BlobApi.test.ts
@@ -78,6 +78,30 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
+    it("checkBlobExistsStatus", async () => {
+        const params = {
+            layerId: "mocked-id",
+            dataHandle: "mocked-datahandle",
+            billingTag: "mocked-billingTag"
+        };
+        const builder = {
+            baseUrl: "http://mocked.url",
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
+                expect(urlBuilder.url).to.be.equal(
+                    "http://mocked.url/layers/mocked-id/data/mocked-datahandle?billingTag=mocked-billingTag"
+                );
+                expect(options.method).to.be.equal("HEAD");
+                return Promise.resolve("success");
+            }
+        };
+        const result = await BlobApi.checkBlobExistsStatus(
+            (builder as unknown) as RequestBuilder,
+            params
+        );
+
+        expect(result).to.be.equal("success");
+    });
+
     it("completeMultipartUpload", async () => {
         const params = {
             layerId: "mocked-id",

--- a/@here/olp-sdk-dataservice-write/lib/client/CheckDataExistsRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/CheckDataExistsRequest.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+/**
+ * @brief Check data existence request structure holding all necessary information.
+ */
+export class CheckDataExistsRequest {
+    private layerId?: string;
+    private dataHandle?: string;
+    private billingTag?: string;
+
+    /**
+     * @brief set the ID of the layer to check if data exist.
+     * @param layerId the ID of the layer.
+     * @note Required.
+     *
+     * @returns reference to this object
+     */
+    public withLayerId(layerId: string): CheckDataExistsRequest {
+        this.layerId = layerId;
+        return this;
+    }
+
+    /**
+     * @brief get the ID of the layer.
+     * @returns The ID of the layer to check.
+     */
+    public getLayerId(): string | undefined {
+        return this.layerId;
+    }
+
+    /**
+     * @brief set the DataHandle to check if data exist.
+     * @param dataHandele string. Can be any unique number or a hash of the content or metadata.
+     * Data handles must be unique within the layer across all versions.
+     *
+     * @note Required.
+     *
+     * @returns reference to this object
+     */
+    public withDataHandle(dataHandle: string): CheckDataExistsRequest {
+        this.dataHandle = dataHandle;
+        return this;
+    }
+
+    /**
+     * @brief get the DataHandle.previously set or undefined
+     * @returns The datahandle.
+     */
+    public getDataHandle(): string | undefined {
+        return this.dataHandle;
+    }
+
+    /**
+     * @param billing_tag An optional free-form tag which is used for grouping
+     * billing records together. If supplied, it must be between 4 - 16
+     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
+     *
+     * @note Optional.
+     */
+    public withBillingTag(tag: string): CheckDataExistsRequest {
+        this.billingTag = tag;
+        return this;
+    }
+
+    /**
+     * @return Billing Tag previously set or undefined.
+     */
+    public getBillingTag(): string | undefined {
+        return this.billingTag;
+    }
+}

--- a/@here/olp-sdk-dataservice-write/lib/client/index.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/index.ts
@@ -20,3 +20,4 @@
 export * from "./VersionedLayerClient";
 export * from "./StartBatchRequest";
 export * from "./CancelBatchRequest";
+export * from "./CheckDataExistsRequest";

--- a/@here/olp-sdk-dataservice-write/test/unit/CheckDataExistsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/CheckDataExistsRequest.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+import { CheckDataExistsRequest } from "@here/olp-sdk-dataservice-write";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("CheckDataExistsRequest", () => {
+    it("Should initialize", () => {
+        const request = new CheckDataExistsRequest();
+
+        assert.isDefined(request);
+        expect(request).be.instanceOf(CheckDataExistsRequest);
+    });
+
+    it("Should set and get parameters", () => {
+        const mockedLayer = "layer-0";
+        const mockedBillingTag = "mocked-billing-tag";
+        const mockedDataHandle = "datahandle123";
+
+        const request = new CheckDataExistsRequest()
+            .withLayerId(mockedLayer)
+            .withDataHandle(mockedDataHandle)
+            .withBillingTag(mockedBillingTag);
+
+        expect(request.getLayerId()).to.be.equal(mockedLayer);
+        expect(request.getBillingTag()).to.be.equal(mockedBillingTag);
+        expect(request.getDataHandle()).to.be.equal(mockedDataHandle);
+    });
+});


### PR DESCRIPTION
When submitting a blob for publication the user should have
the possibility to provide it's own data handle.

Data handles must be unique within the layer across all
versions and should be checked against Blob API before
used if it does not exists yet.
In case data handle exists, a new one needs to be generated
and checked again until one is found that is not present
in the blob store.

To give user the possibility to generate his own data handle
and to check that it is not used we exposing a method
`CheckDataExists` anf request class `CheckDataExistsRequest`.

Also fixing crash in the function `checkBlobExists` of blob-api
and adding unit tests.

Relates-To: OLPEDGE-2047

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>