### PR TITLE
Add method publishToBatch

### DIFF
--- a/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
+++ b/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
@@ -49,8 +49,9 @@ class DeferredPromise<T> {
 }
 
 enum STATUS_CODES {
-    Ok = 200,
+    OK = 200,
     CREATED = 201,
+    NO_CONTENT = 204,
     SERVICE_UNAVAIBLE = 503
 }
 
@@ -104,7 +105,8 @@ export class DataStoreDownloadManager implements DownloadManager {
                 retryCount >= maxRetries
             ) {
                 if (
-                    response.status === STATUS_CODES.Ok ||
+                    response.status === STATUS_CODES.OK ||
+                    response.status === STATUS_CODES.NO_CONTENT ||
                     response.status === STATUS_CODES.CREATED
                 ) {
                     return Promise.resolve(response);

--- a/@here/olp-sdk-dataservice-api/lib/publish-api-v2.ts
+++ b/@here/olp-sdk-dataservice-api/lib/publish-api-v2.ts
@@ -310,7 +310,7 @@ export async function initPublication(
 export async function submitPublication(
     builder: RequestBuilder,
     params: { publicationId: string; billingTag?: string }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/publications/{publicationId}".replace(
         "{publicationId}",
         UrlBuilder.toString(params["publicationId"])
@@ -325,7 +325,7 @@ export async function submitPublication(
         headers
     };
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -350,7 +350,7 @@ export async function uploadPartitions(
         body: PublishPartitions;
         billingTag?: string;
     }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/publications/{publicationId}/partitions"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace(
@@ -371,5 +371,5 @@ export async function uploadPartitions(
         options.body = JSON.stringify(params["body"]);
     }
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }

--- a/@here/olp-sdk-dataservice-api/test/PublishApiV2.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/PublishApiV2.test.ts
@@ -94,7 +94,10 @@ describe("PublishApi", () => {
         };
         const builder = {
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: RequestInit) => {
+            requestBlob: async (
+                urlBuilder: UrlBuilder,
+                options: RequestInit
+            ) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/publications/mocked-publicationId?billingTag=mocked-billingTag"
                 );
@@ -124,7 +127,7 @@ describe("PublishApi", () => {
         };
         const builder = {
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/layers/mocked-layer-id/publications/mocked-publicationId/partitions?billingTag=mocked-billingTag"
                 );

--- a/@here/olp-sdk-dataservice-write/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/VersionedLayerClient.ts
@@ -19,9 +19,9 @@
 
 import {
     HRN,
-    HttpError,
     OlpClientSettings,
-    RequestFactory
+    RequestFactory,
+    Uuid
 } from "@here/olp-sdk-core";
 import {
     BlobApi,
@@ -32,6 +32,7 @@ import {
     CancelBatchRequest,
     CheckDataExistsRequest,
     CompleteBatchRequest,
+    PublishSinglePartitionRequest,
     StartBatchRequest
 } from "@here/olp-sdk-dataservice-write";
 
@@ -213,6 +214,113 @@ export class VersionedLayerClient {
     }
 
     /**
+     * @breaf Gives the user the possibility to upload one partition blob and metadata at once
+     * @param request PublishSinglePartitionRequest with needed params
+     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * and, if required, abort it using the `AbortController` object.
+     *
+     * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+     *
+     * @returns Promise resolves if the operation was successful. Rejects if unsuccessful.
+     */
+    public async publishToBatch(
+        request: PublishSinglePartitionRequest,
+        abortSignal?: AbortSignal
+    ): Promise<Response> {
+        const metadata = request.getMetadata();
+        if (!metadata) {
+            return Promise.reject(
+                new Error(
+                    "Please set metadata to the PublishSinglePartitionRequest"
+                )
+            );
+        }
+
+        if (!metadata.partition) {
+            return Promise.reject(new Error(`Partition ID is missing`));
+        }
+
+        const body = request.getData();
+        if (!body) {
+            return Promise.reject(
+                new Error(
+                    "Please set data to the PublishSinglePartitionRequest"
+                )
+            );
+        }
+
+        if (!metadata.dataSize) {
+            metadata.dataSize =
+                body instanceof Buffer ? body.byteLength : body.size;
+        }
+
+        const layerId = request.getLayerId();
+        if (!layerId) {
+            return Promise.reject(
+                new Error(
+                    "Please set layerId to the PublishSinglePartitionRequest"
+                )
+            );
+        }
+
+        const publicationId = request.getPublicationId();
+        if (!publicationId) {
+            return Promise.reject(
+                new Error(
+                    "Please set publicationId to the PublishSinglePartitionRequest"
+                )
+            );
+        }
+
+        if (!metadata.dataHandle) {
+            metadata.dataHandle = Uuid.create();
+        }
+
+        const publishRequestBuilder = await RequestFactory.create(
+            "publish",
+            "v2",
+            this.params.settings,
+            this.params.catalogHrn,
+            abortSignal
+        ).catch((err: Response) =>
+            Promise.reject(
+                new Error(
+                    `Error retrieving from cache builder for resource "${this.params.catalogHrn}" and api: publish. ${err}`
+                )
+            )
+        );
+
+        const blobRequestBuilder = await RequestFactory.create(
+            "blob",
+            "v1",
+            this.params.settings,
+            this.params.catalogHrn,
+            abortSignal
+        ).catch(error =>
+            Promise.reject(
+                new Error(
+                    `Error retrieving from cache requestBuilder for resource "${this.params.catalogHrn}" and api: blob. ${error}`
+                )
+            )
+        );
+
+        await BlobApi.putData(blobRequestBuilder, {
+            layerId,
+            body,
+            contentLength: `${metadata.dataSize}`,
+            dataHandle: metadata.dataHandle as string
+        }).catch(error => Promise.reject(error));
+
+        return PublishApi.uploadPartitions(publishRequestBuilder, {
+            layerId,
+            publicationId,
+            body: {
+                partitions: [metadata]
+            }
+        });
+    }
+
+    /**
      * Cancels a publication if it has not yet been submitted.
      * Will fail if attempting to cancel a submitted publication.
      * This allows the specified publication to be abandoned.
@@ -228,7 +336,7 @@ export class VersionedLayerClient {
     public async cancelBatch(
         request: CancelBatchRequest,
         abortSignal?: AbortSignal
-    ): Promise<boolean> {
+    ): Promise<Response> {
         const requestBuilder = await RequestFactory.create(
             "publish",
             "v2",
@@ -252,14 +360,10 @@ export class VersionedLayerClient {
             );
         }
 
-        const result = await PublishApi.cancelPublication(requestBuilder, {
+        return PublishApi.cancelPublication(requestBuilder, {
             publicationId,
             billingTag: request.getBillingTag()
-        }).catch(error => error);
-
-        return result.status === 204
-            ? Promise.resolve(true)
-            : Promise.reject(result);
+        });
     }
 
     /**
@@ -312,10 +416,6 @@ export class VersionedLayerClient {
         return PublishApi.submitPublication(requestBuilder, {
             publicationId,
             billingTag: request.getBillingTag()
-        }).catch(async (response: HttpError) => {
-            return response.status === 204
-                ? Promise.resolve(response)
-                : Promise.reject(response);
         });
     }
 }

--- a/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
@@ -246,7 +246,7 @@ describe("VersionedLayerClient write", function() {
         const response = await client.cancelBatch(
             new CancelBatchRequest().withPublicationId("mocked-pub-id")
         );
-        expect(response).equals(true);
+        expect(response.status === 204).equals(true);
     });
 
     it("Should rejects with error a cancel the publication operation", async function() {
@@ -289,7 +289,7 @@ describe("VersionedLayerClient write", function() {
 
     it("Should submit the publication", async function() {
         submitPublicationStub.callsFake(() => {
-            return Promise.reject({
+            return Promise.resolve({
                 status: 204
             });
         });


### PR DESCRIPTION
The method provides a possibility to upload and publish data
in one call. Data should be less than 50Mb.

Also in CR are fixes and improvements.

Resolves: OLPEDGE-2054, OLPEDGE-2003