### PR TITLE
Add a retry logic in case datahandle exist.

### DIFF
--- a/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
+++ b/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { DownloadManager, HttpError } from "@here/olp-sdk-core";
+import { DownloadManager, HttpError, STATUS_CODES } from "@here/olp-sdk-core";
 
 /** @internal
  * 'DeferredPromise' takes an executor function for executing it later, when [[exec]] is called.
@@ -46,13 +46,6 @@ class DeferredPromise<T> {
             .then(this.resolveFunc)
             .catch(this.rejectFunc);
     }
-}
-
-enum STATUS_CODES {
-    OK = 200,
-    CREATED = 201,
-    NO_CONTENT = 204,
-    SERVICE_UNAVAIBLE = 503
 }
 
 /**

--- a/@here/olp-sdk-core/lib/utils/index.ts
+++ b/@here/olp-sdk-core/lib/utils/index.ts
@@ -17,6 +17,17 @@
  * License-Filename: LICENSE
  */
 
+/**
+ * Status codes of HTTP responses.
+ */
+export enum STATUS_CODES {
+    OK = 200,
+    CREATED = 201,
+    NO_CONTENT = 204,
+    NOT_FOUND = 404,
+    SERVICE_UNAVAIBLE = 503
+}
+
 export * from "./DataStoreDownloadManager";
 export * from "./DataStoreRequestBuilder";
 export * from "./DownloadManager";


### PR DESCRIPTION
If datahandle was not provided, we generate the UUID and use it
as datahandle.
A retry logic in case datahandle is already present is a loop of
3 tries and each time we generate a new UUID and retry.
If all thies was not success, the method rejects the promise
with Error.

Make enum STATUS_CODES public and move to the core package to share
for all components.

Resolves: OLPEDGE-2088

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>