### PR TITLE
Stop using arrow functions in tests.

### DIFF
--- a/@here/olp-sdk-authentication/test/OAuth.test.ts
+++ b/@here/olp-sdk-authentication/test/OAuth.test.ts
@@ -31,13 +31,13 @@ const MOCK_UPDATED_TIME = 1550777141;
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("oauth-request", () => {
+describe("oauth-request", function() {
     // requires CONSUMER_KEY and SECRET_KEY env variables, disabled by default
-    xit("requestTokenOnline", async () => {
+    xit("requestTokenOnline", async function() {
         let consumerKey = "";
         let secretKey = "";
 
-        assert.doesNotThrow(() => {
+        assert.doesNotThrow(function() {
             consumerKey = process.env.CONSUMER_KEY as string;
             secretKey = process.env.SECRET_KEY as string;
         });
@@ -58,12 +58,12 @@ describe("oauth-request", () => {
     });
 });
 
-describe("oauth-request-offline", () => {
+describe("oauth-request-offline", function() {
     const mock_token = "eyJhbGciOiJSUzUxMiIsImN0eSI6IkpXVCIsIm";
     const mock_id = "mock-id";
     const mock_scrt = "mock-str";
 
-    beforeEach(() => {
+    beforeEach(function() {
         fetchMock.config.overwriteRoutes = true;
         fetchMock.post("https://account.api.here.com/oauth2/token", {
             accessToken: mock_token,
@@ -72,7 +72,7 @@ describe("oauth-request-offline", () => {
         });
     });
 
-    afterEach(() => {
+    afterEach(function() {
         fetchMock.reset();
     });
 
@@ -93,7 +93,7 @@ describe("oauth-request-offline", () => {
         );
     });
 
-    it("requestToken", async () => {
+    it("requestToken", async function() {
         const consumerKey = "key";
         const secretKey = "secret";
 
@@ -108,7 +108,7 @@ describe("oauth-request-offline", () => {
         assert.isNotEmpty(reply.accessToken);
     });
 
-    it("getTokenAuthModeFile", async () => {
+    it("getTokenAuthModeFile", async function() {
         let token: string | null = null;
         const credentialsFilePath = "./test/test-credentials.properties";
         const credentials = loadCredentialsFromFile(credentialsFilePath);
@@ -128,7 +128,7 @@ describe("oauth-request-offline", () => {
         }
     });
 
-    it("getTokenAuthModeForm", async () => {
+    it("getTokenAuthModeForm", async function() {
         let token: string | null = null;
 
         const userAuth = new UserAuth({
@@ -149,7 +149,7 @@ describe("oauth-request-offline", () => {
         }
     });
 
-    it("validateAccessToken", async () => {
+    it("validateAccessToken", async function() {
         const userAuth = new UserAuth({
             credentials: {
                 accessKeyId: mock_id,
@@ -172,7 +172,7 @@ describe("oauth-request-offline", () => {
         }
     });
 
-    it("validateAccessTokenFalse", async () => {
+    it("validateAccessTokenFalse", async function() {
         const userAuth = new UserAuth({
             credentials: {
                 accessKeyId: mock_id,
@@ -196,7 +196,7 @@ describe("oauth-request-offline", () => {
         });
     });
 
-    it("getAccessTokenFalse", async () => {
+    it("getAccessTokenFalse", async function() {
         const userAuth = new UserAuth({
             credentials: {
                 accessKeyId: mock_id,
@@ -221,12 +221,12 @@ describe("oauth-request-offline", () => {
     });
 });
 
-describe("oauth-request-lookupapi", () => {
+describe("oauth-request-lookupapi", function() {
     const mock_token = "eyJhbGciOiJSUzUxMiIsImN0eSI6IkpXVCIsIm";
     const mock_id = "mock-id";
     const mock_scrt = "mock-str";
 
-    beforeEach(() => {
+    beforeEach(function() {
         fetchMock.config.overwriteRoutes = true;
         fetchMock.post("https://account.api.here.com/oauth2/token", {
             accessToken: mock_token,
@@ -235,11 +235,11 @@ describe("oauth-request-lookupapi", () => {
         });
     });
 
-    afterEach(() => {
+    afterEach(function() {
         fetchMock.reset();
     });
 
-    it("getUserInfo-ProdEnv", async () => {
+    it("getUserInfo-ProdEnv", async function() {
         const userAuth = new UserAuth({
             env: "here",
             credentials: {
@@ -287,7 +287,7 @@ describe("oauth-request-lookupapi", () => {
         }
     });
 
-    it("getUserInfo-DevEnv", async () => {
+    it("getUserInfo-DevEnv", async function() {
         const userAuth = new UserAuth({
             env: "here-dev",
             credentials: {
@@ -335,7 +335,7 @@ describe("oauth-request-lookupapi", () => {
         }
     });
 
-    it("getUserInfo-CnEnv", async () => {
+    it("getUserInfo-CnEnv", async function() {
         const userAuth = new UserAuth({
             env: "here-cn",
             credentials: {
@@ -383,7 +383,7 @@ describe("oauth-request-lookupapi", () => {
         }
     });
 
-    it("getUserInfo-CnDevEnv", async () => {
+    it("getUserInfo-CnDevEnv", async function() {
         const userAuth = new UserAuth({
             env: "here-cn-dev",
             credentials: {
@@ -434,7 +434,7 @@ describe("oauth-request-lookupapi", () => {
         }
     });
 
-    it("getUserInfo-CustomUrl", async () => {
+    it("getUserInfo-CustomUrl", async function() {
         const userAuth = new UserAuth({
             customUrl: "http://localhost/",
             credentials: {
@@ -482,7 +482,7 @@ describe("oauth-request-lookupapi", () => {
         }
     });
 
-    it("getUserInfo-default", async () => {
+    it("getUserInfo-default", async function() {
         const userAuth = new UserAuth({
             credentials: {
                 accessKeyId: mock_id,
@@ -530,7 +530,7 @@ describe("oauth-request-lookupapi", () => {
     });
 });
 
-describe("auth-request-project-scope", () => {
+describe("auth-request-project-scope", function() {
     let token: string | null = null;
     const mockedScope = "mocked-scope";
     const mock_id = "mock-id";
@@ -545,7 +545,7 @@ describe("auth-request-project-scope", () => {
         return Promise.resolve(mockedToken);
     };
 
-    it("Should scope be present on userAuth", async () => {
+    it("Should scope be present on userAuth", async function() {
         const userAuth = new UserAuth({
             env: "here-dev",
             credentials: {
@@ -566,7 +566,7 @@ describe("auth-request-project-scope", () => {
         }
     });
 
-    it("Should customUrl be present in getToken request", async () => {
+    it("Should customUrl be present in getToken request", async function() {
         const mockedUrl = "https://example.com/my/custom/url";
         const mockedTokenRequest = async (params: any): Promise<Token> => {
             assert.strictEqual(params.url, mockedUrl);
@@ -594,7 +594,7 @@ describe("auth-request-project-scope", () => {
     });
 });
 
-describe("expired token refreshing", async () => {
+describe("expired token refreshing", async function() {
     const mockedTokenRequester = async (params: any): Promise<Token> => {
         const mockedToken: Token = {
             accessToken: `${params.url}-${params.consumerKey}`,
@@ -612,7 +612,7 @@ describe("expired token refreshing", async () => {
         }
     });
 
-    it("Should getToken return the same token for two requests in row", async () => {
+    it("Should getToken return the same token for two requests in row", async function() {
         const token1 = await userAuth.getToken();
         const token2 = await userAuth.getToken();
 
@@ -621,10 +621,10 @@ describe("expired token refreshing", async () => {
         expect(token1).to.be.equal(token2);
     });
 
-    it("Should getToken return the different tokens for two requests with delay", async () => {
+    it("Should getToken return the different tokens for two requests with delay", async function() {
         const token1 = await userAuth.getToken();
 
-        setTimeout(async () => {
+        setTimeout(async function() {
             const token2 = await userAuth.getToken();
 
             assert.isDefined(token1);

--- a/@here/olp-sdk-authentication/test/loadCredentialsFromFile.test.ts
+++ b/@here/olp-sdk-authentication/test/loadCredentialsFromFile.test.ts
@@ -20,8 +20,8 @@
 import { assert } from "chai";
 import { loadCredentialsFromFile } from "../lib/loadCredentialsFromFile";
 
-describe("loadCredentialsFromFile", () => {
-    it("should return correct AuthCredentials", () => {
+describe("loadCredentialsFromFile", function() {
+    it("should return correct AuthCredentials", function() {
         const credentials = loadCredentialsFromFile(
             "./test/test-credentials.properties"
         );
@@ -33,7 +33,7 @@ describe("loadCredentialsFromFile", () => {
         );
     });
 
-    it("should throw an error", () => {
+    it("should throw an error", function() {
         try {
             loadCredentialsFromFile("./test/test-error-credentials.properties");
         } catch (error) {

--- a/@here/olp-sdk-authentication/test/requestTokenWeb.test.ts
+++ b/@here/olp-sdk-authentication/test/requestTokenWeb.test.ts
@@ -40,10 +40,10 @@ global.crypto = {
 
 global.btoa = () => "mocked-btoa-string";
 
-describe("oauth-request-offline", () => {
+describe("oauth-request-offline", function() {
     const mock_token = "eyJhbGciOiJSUzUxMiIsImN0eSI6IkpXVCIsIm";
 
-    beforeEach(() => {
+    beforeEach(function() {
         fetchMock.config.overwriteRoutes = true;
         fetchMock.post("https://account.api.here.com/oauth2/token", {
             accessToken: mock_token,
@@ -52,11 +52,11 @@ describe("oauth-request-offline", () => {
         });
     });
 
-    afterEach(() => {
+    afterEach(function() {
         fetchMock.reset();
     });
 
-    it("requestTokenWeb", async () => {
+    it("requestTokenWeb", async function() {
         const consumerKey = "key";
         const secretKey = "secret";
 

--- a/@here/olp-sdk-authentication/tslint.json
+++ b/@here/olp-sdk-authentication/tslint.json
@@ -112,7 +112,7 @@
       "check-whitespace"
     ],
     "only-arrow-functions": [
-      true,
+      false,
       "allow-declarations",
       "allow-named-functions"
     ],

--- a/@here/olp-sdk-core/test/unit/ApiCacheRepository.test.ts
+++ b/@here/olp-sdk-core/test/unit/ApiCacheRepository.test.ts
@@ -27,7 +27,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("ApiCacheRepository", () => {
+describe("ApiCacheRepository", function() {
     let testCache = new lib.KeyValueCache();
     testCache.put("test-key", "test-value");
     let apiCacheRepository = new lib.ApiCacheRepository(testCache);
@@ -44,12 +44,12 @@ describe("ApiCacheRepository", () => {
     const testServiceVersion3 = "service-version3";
     const testServiceUrl3 = "service-url3";
 
-    it("Shoud be initialised", async () => {
+    it("Shoud be initialised", async function() {
         assert.isDefined(apiCacheRepository);
         expect(apiCacheRepository).be.instanceOf(lib.ApiCacheRepository);
     });
 
-    it("Method put should store a new key-value pair in the cache", async () => {
+    it("Method put should store a new key-value pair in the cache", async function() {
         const operationIsSuccessful = apiCacheRepository.put(
             testServiceApiName,
             testServiceVersion,
@@ -67,7 +67,7 @@ describe("ApiCacheRepository", () => {
         ).equal(testServiceUrl);
     });
 
-    it("Method get should return the base URL from the cache.", async () => {
+    it("Method get should return the base URL from the cache.", async function() {
         apiCacheRepository.put(
             testServiceApiName2,
             testServiceVersion2,

--- a/@here/olp-sdk-core/test/unit/DataStoreRequestBuilder.test.ts
+++ b/@here/olp-sdk-core/test/unit/DataStoreRequestBuilder.test.ts
@@ -28,7 +28,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("addBearerToken", () => {
+describe("addBearerToken", function() {
     const USER_AGENT = `OLP-TS-SDK/${lib.LIB_VERSION}`;
     const dm = ({
         download: async (url: string, init?: RequestInit) =>
@@ -41,14 +41,14 @@ describe("addBearerToken", () => {
         () => Promise.resolve("mocked-token")
     );
 
-    it("Shoud be added token to the request headers with empty params from the user", async () => {
+    it("Shoud be added token to the request headers with empty params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url");
         expect(result.headers.get("Authorization")).equals(
             "Bearer mocked-token"
         );
     });
 
-    it("Shoud be added token to the request headers with not empty params from the user", async () => {
+    it("Shoud be added token to the request headers with not empty params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string"
         });
@@ -58,7 +58,7 @@ describe("addBearerToken", () => {
         );
     });
 
-    it("Shoud be added token to the request headers with some headers in params from the user", async () => {
+    it("Shoud be added token to the request headers with some headers in params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string",
             headers: [
@@ -74,7 +74,7 @@ describe("addBearerToken", () => {
         );
     });
 
-    it("Shoud be added token to the request headers with some instance of  Headers in params from the user", async () => {
+    it("Shoud be added token to the request headers with some instance of  Headers in params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string",
             headers: new Headers({ "test-header": "test-header-value" })
@@ -86,7 +86,7 @@ describe("addBearerToken", () => {
         expect(result.headers.get("test-header")).equals("test-header-value");
     });
 
-    it("Shoud be added token to the request headers with some empty headers object in params from the user", async () => {
+    it("Shoud be added token to the request headers with some empty headers object in params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string",
             headers: {}
@@ -97,7 +97,7 @@ describe("addBearerToken", () => {
         );
     });
 
-    it("Shoud be added token to the request headers with some not empty headers object in params from the user", async () => {
+    it("Shoud be added token to the request headers with some not empty headers object in params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string",
             headers: { "test-header": "test-header-value" }
@@ -109,12 +109,12 @@ describe("addBearerToken", () => {
         expect(result.headers.get("test-header")).equals("test-header-value");
     });
 
-    it("Shoud be added user-agent to the request headers with empty params from the user", async () => {
+    it("Shoud be added user-agent to the request headers with empty params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url");
         expect(result.headers.get("User-Agent")).equals(USER_AGENT);
     });
 
-    it("Shoud be added user-agent to the request headers with not empty params from the user", async () => {
+    it("Shoud be added user-agent to the request headers with not empty params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string"
         });
@@ -122,7 +122,7 @@ describe("addBearerToken", () => {
         expect(result.headers.get("User-Agent")).equals(USER_AGENT);
     });
 
-    it("Shoud be added user-agent to the request headers with some headers in params from the user", async () => {
+    it("Shoud be added user-agent to the request headers with some headers in params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string",
             headers: [
@@ -136,7 +136,7 @@ describe("addBearerToken", () => {
         );
     });
 
-    it("Shoud be added token to the request headers with some instance of  Headers in params from the user", async () => {
+    it("Shoud be added token to the request headers with some instance of  Headers in params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string",
             headers: new Headers({ "test-header": "test-header-value" })
@@ -146,7 +146,7 @@ describe("addBearerToken", () => {
         expect(result.headers.get("test-header")).equals("test-header-value");
     });
 
-    it("Shoud be added token to the request headers with some empty headers object in params from the user", async () => {
+    it("Shoud be added token to the request headers with some empty headers object in params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string",
             headers: {}
@@ -155,7 +155,7 @@ describe("addBearerToken", () => {
         expect(result.headers.get("User-Agent")).equals(USER_AGENT);
     });
 
-    it("Shoud be added token to the request headers with some not empty headers object in params from the user", async () => {
+    it("Shoud be added token to the request headers with some not empty headers object in params from the user", async function() {
         const result: any = await requestBuilder.download("mocked-url", {
             body: "test-string",
             headers: { "test-header": "test-header-value" }
@@ -166,7 +166,7 @@ describe("addBearerToken", () => {
     });
 });
 
-describe("DataStoreRequestBuilder", () => {
+describe("DataStoreRequestBuilder", function() {
     let sandbox: sinon.SinonSandbox;
     let getBaseUrlRequestStub: sinon.SinonStub;
 
@@ -197,11 +197,11 @@ describe("DataStoreRequestBuilder", () => {
             } as unknown) as Response)
     } as unknown) as lib.DownloadManager;
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         getBaseUrlRequestStub = sandbox.stub(lib.RequestFactory, "getBaseUrl");
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
 
@@ -220,16 +220,16 @@ describe("DataStoreRequestBuilder", () => {
         );
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Shoud be initialized", async () => {
+    it("Shoud be initialized", async function() {
         assert.isDefined(dataStore);
         expect(dataStore).be.instanceOf(lib.DataStoreRequestBuilder);
     });
 
-    it("Shoud downloads data from the provided URL", async () => {
+    it("Shoud downloads data from the provided URL", async function() {
         const response = await dataStore.download(mockedUrl);
 
         assert.isDefined(response);
@@ -237,7 +237,7 @@ describe("DataStoreRequestBuilder", () => {
         expect(response.statusText).to.be.equal("Test Success");
     });
 
-    it("Shoud download method return error when downloadManager crashed", async () => {
+    it("Shoud download method return error when downloadManager crashed", async function() {
         try {
             await dataStoreError.download(mockedUrl);
         } catch (error) {
@@ -247,7 +247,7 @@ describe("DataStoreRequestBuilder", () => {
         }
     });
 
-    it("Shoud downloads the blob data from the provided URL", async () => {
+    it("Shoud downloads the blob data from the provided URL", async function() {
         const response = await dataStore.downloadBlob(mockedUrl);
 
         assert.isDefined(response);
@@ -255,7 +255,7 @@ describe("DataStoreRequestBuilder", () => {
         expect(response.statusText).to.be.equal("Test Success");
     });
 
-    it("Shoud downloadBlob method return error when downloadManager crashed", async () => {
+    it("Shoud downloadBlob method return error when downloadManager crashed", async function() {
         try {
             await dataStoreError.downloadBlob(mockedUrl);
         } catch (error) {
@@ -265,7 +265,7 @@ describe("DataStoreRequestBuilder", () => {
         }
     });
 
-    it("Shoud abort signal be added to the headers of the requests", async () => {
+    it("Shoud abort signal be added to the headers of the requests", async function() {
         const dm = ({
             download: (url: any, options: any) => {
                 assert.isDefined(options.signal.aborted);

--- a/@here/olp-sdk-core/test/unit/HRN.test.ts
+++ b/@here/olp-sdk-core/test/unit/HRN.test.ts
@@ -20,13 +20,13 @@
 import { assert } from "chai";
 import { HRN } from "@here/olp-sdk-core";
 
-describe("HRN", () => {
-    it("fromString", () => {
+describe("HRN", function() {
+    it("fromString", function() {
         const hrnString = "hrn:here:datastore:::testcatalog";
         assert.strictEqual(HRN.fromString(hrnString).toString(), hrnString);
     });
 
-    it("localURL", () => {
+    it("localURL", function() {
         const hrn = HRN.fromString("http://localhost:5000");
 
         assert.strictEqual(hrn.data.partition, "catalog-url");
@@ -35,7 +35,7 @@ describe("HRN", () => {
         assert.strictEqual(hrn.data.account, "");
     });
 
-    it("additionalFields", () => {
+    it("additionalFields", function() {
         const hrn = HRN.fromString(
             "hrn:here:datastore:::testcatalog:some:additional:fields"
         );
@@ -47,7 +47,7 @@ describe("HRN", () => {
         ]);
     });
 
-    it("HRN throw Error on malformed input data", () => {
+    it("HRN throw Error on malformed input data", function() {
         let caught = false;
         try {
             // tslint:disable-next-line:no-unused-variable

--- a/@here/olp-sdk-core/test/unit/KeyValueCache.test.ts
+++ b/@here/olp-sdk-core/test/unit/KeyValueCache.test.ts
@@ -25,16 +25,16 @@ import { KeyValueCache } from "@here/olp-sdk-core";
 chai.use(sinonChai);
 const expect = chai.expect;
 
-describe("KeyValueCache", () => {
+describe("KeyValueCache", function() {
     let sandbox: sinon.SinonSandbox;
     let keyValueCache1 = new KeyValueCache();
 
-    beforeEach(() => {
+    beforeEach(function() {
         keyValueCache1.put("key1", "value1");
         keyValueCache1.put("key2", "value2");
     });
 
-    it("Should put new key value", () => {
+    it("Should put new key value", function() {
         keyValueCache1.put("key3", "value3");
 
         expect(keyValueCache1.get("key1")).equal("value1");
@@ -42,7 +42,7 @@ describe("KeyValueCache", () => {
         expect(keyValueCache1.get("key3")).equal("value3");
     });
 
-    it("Should put handle error", () => {
+    it("Should put handle error", function() {
         const cache = new KeyValueCache();
         const resp1 = cache.put("key", "somedata");
         expect(resp1).equal(true);
@@ -51,12 +51,12 @@ describe("KeyValueCache", () => {
         expect(resp2).equal(false);
     });
 
-    it("Should getCapacity return cache capacity", () => {
+    it("Should getCapacity return cache capacity", function() {
         const cache = new KeyValueCache();
         expect(cache.getCapacity()).equal(2097152);
     });
 
-    it("Should clear() clear the cache and remove all ietms", () => {
+    it("Should clear() clear the cache and remove all ietms", function() {
         const cache = new KeyValueCache();
         cache.put("key", "value");
         expect(cache.get("key")).equal("value");
@@ -64,7 +64,7 @@ describe("KeyValueCache", () => {
         expect(cache.get("key")).equal(undefined);
     });
 
-    it("Should get key value", () => {
+    it("Should get key value", function() {
         expect(keyValueCache1.get("key1")).equal("value1");
         expect(keyValueCache1.get("key2")).equal("value2");
     });

--- a/@here/olp-sdk-core/test/unit/LRU.test.ts
+++ b/@here/olp-sdk-core/test/unit/LRU.test.ts
@@ -20,8 +20,8 @@
 import { assert } from "chai";
 import { LRUCache } from "@here/olp-sdk-core";
 
-describe("LRU", () => {
-    it("set", () => {
+describe("LRU", function() {
+    it("set", function() {
         const cache = new LRUCache(3);
         cache.set(1, 1);
         cache.set(2, 2);
@@ -32,7 +32,7 @@ describe("LRU", () => {
         assert.strictEqual(cache.get(3), 3);
     });
 
-    it("get", () => {
+    it("get", function() {
         const cache = new LRUCache<number, number>(3);
         assert.strictEqual(cache.get(1), undefined);
         assert.strictEqual(cache.get(2), undefined);
@@ -44,7 +44,7 @@ describe("LRU", () => {
         assert.strictEqual(cache.get(3), undefined);
     });
 
-    it("overflow", () => {
+    it("overflow", function() {
         const cache = new LRUCache(3);
         cache.set(1, 1);
         cache.set(2, 2);
@@ -57,7 +57,7 @@ describe("LRU", () => {
         assert.strictEqual(cache.get(4), 4);
     });
 
-    it("clear", () => {
+    it("clear", function() {
         const cache = new LRUCache(3);
         cache.set(1, 1);
         cache.set(2, 2);
@@ -67,7 +67,7 @@ describe("LRU", () => {
         assert.strictEqual(cache.get(2), undefined);
     });
 
-    it("resize", () => {
+    it("resize", function() {
         const cache = new LRUCache<number, number>(2);
 
         cache.set(1, 1);

--- a/@here/olp-sdk-core/test/unit/OlpClientSettings.test.ts
+++ b/@here/olp-sdk-core/test/unit/OlpClientSettings.test.ts
@@ -51,21 +51,21 @@ class MockedCustomDataStoreDownloadManager {
     }
 }
 
-describe("OlpClientSettings", () => {
+describe("OlpClientSettings", function() {
     let KeyValueCacheStub: sinon.SinonStub;
     let DataStoreDownloadManagerStub: sinon.SinonStub;
 
     let sandbox: sinon.SinonSandbox;
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         KeyValueCacheStub = sandbox.stub(lib, "KeyValueCache");
         KeyValueCacheStub.callsFake((cache, hrn) => new MockedKeyValueCache());
 
@@ -78,7 +78,7 @@ describe("OlpClientSettings", () => {
         );
     });
 
-    it("Should be configured with correct params and default download manager", async () => {
+    it("Should be configured with correct params and default download manager", async function() {
         const settings = new lib.OlpClientSettings({
             environment: "test-env",
             getToken: () => Promise.resolve("test-token")
@@ -100,7 +100,7 @@ describe("OlpClientSettings", () => {
         expect(tokenStr).equal("test-token");
     });
 
-    it("Should be configured with correct params and custom download manager", async () => {
+    it("Should be configured with correct params and custom download manager", async function() {
         const settings = new lib.OlpClientSettings({
             environment: "test-env",
             getToken: () => Promise.resolve("test-token"),

--- a/@here/olp-sdk-core/test/unit/RequestBuilderFactory.test.ts
+++ b/@here/olp-sdk-core/test/unit/RequestBuilderFactory.test.ts
@@ -93,21 +93,21 @@ class MockedDataStoreRequestBuilder {
     ) {}
 }
 
-describe("RequestFactory", () => {
+describe("RequestFactory", function() {
     let ApiCacheRepositoryStub: sinon.SinonStub;
     let DataStoreRequestBuilderStub: sinon.SinonStub;
 
     let sandbox: sinon.SinonSandbox;
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         ApiCacheRepositoryStub = sandbox.stub(lib, "ApiCacheRepository");
         ApiCacheRepositoryStub.callsFake(
             (cache, hrn) => new MockedApiCacheRepository(cache, hrn)
@@ -126,8 +126,8 @@ describe("RequestFactory", () => {
             .callsFake(() => "http://fake-lookup.service.url");
     });
 
-    describe("create()", () => {
-        it("Should return created RequestBuilder with correct base url for platform service", async () => {
+    describe("create()", function() {
+        it("Should return created RequestBuilder with correct base url for platform service", async function() {
             const headers = new Headers();
             headers.append("cache-control", "max-age=3600");
             const response = {
@@ -162,7 +162,7 @@ describe("RequestFactory", () => {
             );
         });
 
-        it("Should reject with correct error about base url", async () => {
+        it("Should reject with correct error about base url", async function() {
             sandbox
                 .stub(dataServiceApi.LookupApi, "getPlatformAPIList")
                 .callsFake(
@@ -190,8 +190,8 @@ describe("RequestFactory", () => {
         });
     });
 
-    describe("getBaseUrl()", () => {
-        it("Should return correct base url for platform service", async () => {
+    describe("getBaseUrl()", function() {
+        it("Should return correct base url for platform service", async function() {
             const headers = new Headers();
             headers.append("cache-control", "max-age=3600");
             const response = {
@@ -221,7 +221,7 @@ describe("RequestFactory", () => {
             expect(baseUrl).to.be.equal("test-base-url-to-platform-service");
         });
 
-        it("Should return correct base url for resource service", async () => {
+        it("Should return correct base url for resource service", async function() {
             const headers = new Headers();
             headers.append("cache-control", "max-age=3600");
             const response = {
@@ -257,7 +257,7 @@ describe("RequestFactory", () => {
             expect(baseUrl).to.be.equal("test-base-url-to-resource-service");
         });
 
-        it("Should reject with correct error message", async () => {
+        it("Should reject with correct error message", async function() {
             sandbox
                 .stub(dataServiceApi.LookupApi, "getPlatformAPIList")
                 .callsFake(() =>
@@ -282,7 +282,7 @@ describe("RequestFactory", () => {
             }
         });
 
-        it("Should reject with correct custom error message", async () => {
+        it("Should reject with correct custom error message", async function() {
             sandbox
                 .stub(dataServiceApi.LookupApi, "getPlatformAPIList")
                 .callsFake(() =>
@@ -304,7 +304,7 @@ describe("RequestFactory", () => {
             }
         });
 
-        it("Should reject with not found error message", async () => {
+        it("Should reject with not found error message", async function() {
             const headers = new Headers();
             headers.append("cache-control", "max-age=3600");
             const response = {
@@ -337,7 +337,7 @@ describe("RequestFactory", () => {
             }
         });
 
-        it("Should reject with not found error message for hrn", async () => {
+        it("Should reject with not found error message for hrn", async function() {
             const headers = new Headers();
             headers.append("cache-control", "max-age=3600");
             const response = {
@@ -378,7 +378,7 @@ describe("RequestFactory", () => {
             }
         });
 
-        it("Should return correct base url for resource service from cache while max-age is valid", async () => {
+        it("Should return correct base url for resource service from cache while max-age is valid", async function() {
             const headers = new Headers();
             headers.append("cache-control", "max-age=2");
             const response = {
@@ -435,7 +435,7 @@ describe("RequestFactory", () => {
             expect(resourceApiStub.callCount).to.be.equal(1);
             expect(baseUrl2).to.be.equal("test-base-url-to-resource-service");
 
-            setTimeout(async () => {
+            setTimeout(async function() {
                 const baseUrl3 = await lib.RequestFactory.getBaseUrl(
                     "statistics",
                     "v1",

--- a/@here/olp-sdk-core/test/unit/TileKey.test.ts
+++ b/@here/olp-sdk-core/test/unit/TileKey.test.ts
@@ -17,9 +17,6 @@
  * License-Filename: LICENSE
  */
 
-// tslint:disable:only-arrow-functions
-//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
-
 import { assert } from "chai";
 import { TileKey } from "@here/olp-sdk-core";
 

--- a/@here/olp-sdk-core/test/unit/Uuid.test.ts
+++ b/@here/olp-sdk-core/test/unit/Uuid.test.ts
@@ -17,9 +17,6 @@
  * License-Filename: LICENSE
  */
 
-// tslint:disable:only-arrow-functions
-//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
-
 import { assert } from "chai";
 import { Uuid } from "@here/olp-sdk-core";
 

--- a/@here/olp-sdk-core/test/unit/getEnvLookupUrl.test.ts
+++ b/@here/olp-sdk-core/test/unit/getEnvLookupUrl.test.ts
@@ -25,8 +25,8 @@ chai.use(sinonChai);
 
 const expect = chai.expect;
 
-describe("getEnvLookUpUrl", () => {
-    it("Should return default url", () => {
+describe("getEnvLookUpUrl", function() {
+    it("Should return default url", function() {
         expect(getEnvLookUpUrl("invalid environment name string")).to.be.equal(
             "https://api-lookup.data.api.platform.here.com/lookup/v1"
         );
@@ -35,37 +35,37 @@ describe("getEnvLookUpUrl", () => {
         );
     });
 
-    it("Should return url to the development instance", () => {
+    it("Should return url to the development instance", function() {
         expect(getEnvLookUpUrl("here-dev")).to.be.equal(
             "https://api-lookup.data.api.platform.in.here.com/lookup/v1"
         );
     });
 
-    it("Should return url to the production instance", () => {
+    it("Should return url to the production instance", function() {
         expect(getEnvLookUpUrl("here")).to.be.equal(
             "https://api-lookup.data.api.platform.here.com/lookup/v1"
         );
     });
 
-    it("Should return url to the china production instance", () => {
+    it("Should return url to the china production instance", function() {
         expect(getEnvLookUpUrl("here-cn")).to.be.equal(
             "https://api-lookup.data.api.platform.hereolp.cn/lookup/v1"
         );
     });
 
-    it("Should return url to the china development instance", () => {
+    it("Should return url to the china development instance", function() {
         expect(getEnvLookUpUrl("here-cn-dev")).to.be.equal(
             "https://api-lookup.data.api.platform.in.hereolp.cn/lookup/v1"
         );
     });
 
-    it("Should return url to the localhost instance", () => {
+    it("Should return url to the localhost instance", function() {
         expect(getEnvLookUpUrl("local")).to.be.equal(
             "http://localhost:31005/lookup/v1"
         );
     });
 
-    it("Should return url to the custom instance", () => {
+    it("Should return url to the custom instance", function() {
         expect(getEnvLookUpUrl("http://localhost:3000/lookup/v1")).to.be.equal(
             "http://localhost:3000/lookup/v1"
         );

--- a/@here/olp-sdk-dataservice-api/test/ArtifactApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/ArtifactApi.test.ts
@@ -27,8 +27,8 @@ chai.use(sinonChai);
 
 const expect = chai.expect;
 
-describe("ArtifactApi", () => {
-    it("deleteArtifactUsingDELETE", async () => {
+describe("ArtifactApi", function() {
+    it("deleteArtifactUsingDELETE", async function() {
         const params = {
             artifactHrn: "mocked-artifactHrn"
         };
@@ -50,7 +50,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("deleteFileUsingDELETE", async () => {
+    it("deleteFileUsingDELETE", async function() {
         const params = {
             artifactHrn: "mocked-artifactHrn",
             fileName: "mocked-fileName"
@@ -73,7 +73,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getArtifactFileUsingGET", async () => {
+    it("getArtifactFileUsingGET", async function() {
         const params = {
             artifactHrn: "mocked-artifactHrn",
             fileName: "mocked-fileName"
@@ -96,7 +96,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getArtifactUsingGET", async () => {
+    it("getArtifactUsingGET", async function() {
         const params = {
             artifactHrn: "mocked-artifactHrn",
             fileName: "mocked-fileName"
@@ -119,7 +119,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("putArtifactFileUsingPUT", async () => {
+    it("putArtifactFileUsingPUT", async function() {
         const params = {
             artifactHrn: "mocked-artifactHrn",
             fileName: "mocked-fileName",
@@ -147,7 +147,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("registerArtifactUsingPUT", async () => {
+    it("registerArtifactUsingPUT", async function() {
         const params = {
             groupId: "mocked-groupId",
             artifactId: "mocked-artifactId",
@@ -177,7 +177,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("deleteSchemaUsingDELETE", async () => {
+    it("deleteSchemaUsingDELETE", async function() {
         const params = {
             schemaHrn: "mocked-schemaHrn"
         };
@@ -199,7 +199,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getDocumentUsingGET", async () => {
+    it("getDocumentUsingGET", async function() {
         const params = {
             schemaHrn: "mocked-schemaHrn",
             file: "mocked-file"
@@ -222,7 +222,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getSchemaUsingGET", async () => {
+    it("getSchemaUsingGET", async function() {
         const params = {
             schemaHrn: "mocked-schemaHrn"
         };
@@ -244,7 +244,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("listUsingGET", async () => {
+    it("listUsingGET", async function() {
         const params = {
             sort: "mocked-sort",
             order: "mocked-order" as any,
@@ -269,7 +269,7 @@ describe("ArtifactApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("updateSchemaPermissionUsingPOST", async () => {
+    it("updateSchemaPermissionUsingPOST", async function() {
         const params = {
             schemaHrn: "mocked-schemaHrn",
             updatePermissionRequest: "mocked-updatePermissionRequest" as any

--- a/@here/olp-sdk-dataservice-api/test/BlobApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/BlobApi.test.ts
@@ -28,8 +28,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("BlobApi", () => {
-    it("cancelMultipartUpload", async () => {
+describe("BlobApi", function() {
+    it("cancelMultipartUpload", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -54,7 +54,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("checkBlobExists", async () => {
+    it("checkBlobExists", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -78,7 +78,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("checkBlobExistsStatus", async () => {
+    it("checkBlobExistsStatus", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -102,7 +102,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("completeMultipartUpload", async () => {
+    it("completeMultipartUpload", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -135,7 +135,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("doCompleteMultipartUpload", async () => {
+    it("doCompleteMultipartUpload", async function() {
         const params = {
             url:
                 "http://mocked.url/layers/mocked-id/data/mocked-datahandle/multiparts/mocked-multiPartToken",
@@ -171,7 +171,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("deleteBlob", async () => {
+    it("deleteBlob", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -195,7 +195,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getBlob", async () => {
+    it("getBlob", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -221,7 +221,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getMultipartUploadStatus", async () => {
+    it("getMultipartUploadStatus", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -246,7 +246,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("putBlob", async () => {
+    it("putBlob", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -276,7 +276,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("putData", async () => {
+    it("putData", async function() {
         const content = Buffer.from("mocked-data", "utf8");
         const params = {
             layerId: "mocked-id",
@@ -307,7 +307,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("startMultipartUpload", async () => {
+    it("startMultipartUpload", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -333,7 +333,7 @@ describe("BlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("uploadPart", async () => {
+    it("uploadPart", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -370,7 +370,7 @@ describe("BlobApi", () => {
     });
 });
 
-it("doUploadPart", async () => {
+it("doUploadPart", async function() {
     const params = {
         url:
             "http://mocked.url/layers/mocked-id/data/mocked-datahandle/multiparts/mocked-multiPartToken/parts",

--- a/@here/olp-sdk-dataservice-api/test/ConfigApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/ConfigApi.test.ts
@@ -27,8 +27,8 @@ chai.use(sinonChai);
 
 const expect = chai.expect;
 
-describe("ConfigApi", () => {
-    it("catalogExists", async () => {
+describe("ConfigApi", function() {
+    it("catalogExists", async function() {
         const params = {
             catalogHrn: "mocked-catalogHrn",
             billingTag: "mocked-billingTag"
@@ -51,7 +51,7 @@ describe("ConfigApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("createCatalog", async () => {
+    it("createCatalog", async function() {
         const params = {
             body: "mocked-body" as any,
             billingTag: "mocked-billingTag"
@@ -75,7 +75,7 @@ describe("ConfigApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("deleteCatalog", async () => {
+    it("deleteCatalog", async function() {
         const params = {
             catalogHrn: "mocked-catalogHrn",
             billingTag: "mocked-billingTag"
@@ -98,7 +98,7 @@ describe("ConfigApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("deleteLayer", async () => {
+    it("deleteLayer", async function() {
         const params = {
             catalogHrn: "mocked-catalogHrn",
             layerId: "mocked-layerId"
@@ -121,7 +121,7 @@ describe("ConfigApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getCatalog", async () => {
+    it("getCatalog", async function() {
         const params = {
             catalogHrn: "mocked-catalogHrn",
             billingTag: "mocked-billingTag"
@@ -144,7 +144,7 @@ describe("ConfigApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getCatalogStatus", async () => {
+    it("getCatalogStatus", async function() {
         const params = {
             token: "mocked-token",
             billingTag: "mocked-billingTag"
@@ -167,7 +167,7 @@ describe("ConfigApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getCatalogs", async () => {
+    it("getCatalogs", async function() {
         const params = {
             billingTag: "mocked-billingTag" as any,
             verbose: "mocked-verbose" as any,
@@ -203,7 +203,7 @@ describe("ConfigApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("patchCatalog", async () => {
+    it("patchCatalog", async function() {
         const params = {
             catalogHrn: "mocked-catalogHrn",
             body: "mocked-body" as any
@@ -230,7 +230,7 @@ describe("ConfigApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("patchLayer", async () => {
+    it("patchLayer", async function() {
         const params = {
             catalogHrn: "mocked-catalogHrn",
             layerId: "mocked-layerId",
@@ -258,7 +258,7 @@ describe("ConfigApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("updateCatalog", async () => {
+    it("updateCatalog", async function() {
         const params = {
             catalogHrn: "mocked-catalogHrn",
             body: "mocked-body" as any,

--- a/@here/olp-sdk-dataservice-api/test/CoverageApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/CoverageApi.test.ts
@@ -27,8 +27,8 @@ chai.use(sinonChai);
 
 const expect = chai.expect;
 
-describe("CoverageApi", () => {
-    it("getDataCoverageAdminAreas", async () => {
+describe("CoverageApi", function() {
+    it("getDataCoverageAdminAreas", async function() {
         const params = {
             layerId: "mocked-layerId",
             datalevel: "mocked-datalevel"
@@ -51,7 +51,7 @@ describe("CoverageApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getDataCoverageSizeMap", async () => {
+    it("getDataCoverageSizeMap", async function() {
         const params = {
             layerId: "mocked-layerId",
             datalevel: 12
@@ -74,7 +74,7 @@ describe("CoverageApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getDataCoverageSummary", async () => {
+    it("getDataCoverageSummary", async function() {
         const params = {
             layerId: "mocked-layerId"
         };
@@ -96,7 +96,7 @@ describe("CoverageApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getDataCoverageTile", async () => {
+    it("getDataCoverageTile", async function() {
         const params = {
             layerId: "mocked-layerId",
             datalevel: 12
@@ -119,7 +119,7 @@ describe("CoverageApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getDataCoverageTimeMap", async () => {
+    it("getDataCoverageTimeMap", async function() {
         const params = {
             layerId: "mocked-layerId",
             datalevel: 12,

--- a/@here/olp-sdk-dataservice-api/test/DataStoreApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/DataStoreApi.test.ts
@@ -19,8 +19,8 @@
 
 import { assert } from "chai";
 
-describe("DataStoreApiTest", () => {
-    it("ok", () => {
+describe("DataStoreApiTest", function() {
+    it("ok", function() {
         assert(true);
     });
 });

--- a/@here/olp-sdk-dataservice-api/test/HttpError.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/HttpError.test.ts
@@ -23,17 +23,17 @@ import { HttpError } from "../index";
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("HttpErrorTest", () => {
+describe("HttpErrorTest", function() {
     const NOT_FOUND_ERROR_CODE = 404;
     const error = new HttpError(NOT_FOUND_ERROR_CODE, "Not found");
 
-    it("HttpError shoud be initialized", async () => {
+    it("HttpError shoud be initialized", async function() {
         assert.isDefined(error);
         expect(error).to.be.instanceOf(Error);
         expect(error).to.be.instanceOf(HttpError);
     });
 
-    it("HttpError should have parameters status, message and name", async () => {
+    it("HttpError should have parameters status, message and name", async function() {
         expect(error.status).to.be.equal(NOT_FOUND_ERROR_CODE);
         expect(error.message).to.be.equal("Not found");
         expect(error.name).to.be.equal("HttpError");

--- a/@here/olp-sdk-dataservice-api/test/IndexApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/IndexApi.test.ts
@@ -28,8 +28,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("IndexApi", () => {
-    it("Should performQuery provide data", async () => {
+describe("IndexApi", function() {
+    it("Should performQuery provide data", async function() {
         const mockedResponse = {
             data: [
                 {

--- a/@here/olp-sdk-dataservice-api/test/LookupApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/LookupApi.test.ts
@@ -27,8 +27,8 @@ chai.use(sinonChai);
 
 const expect = chai.expect;
 
-describe("lookupAPI", () => {
-    it("platformAPI", async () => {
+describe("lookupAPI", function() {
+    it("platformAPI", async function() {
         const params = {
             api: "mocked-api",
             version: "mocked-version"
@@ -51,7 +51,7 @@ describe("lookupAPI", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("platformAPIList", async () => {
+    it("platformAPIList", async function() {
         const builder = {
             baseUrl: "http://mocked.url",
             request: async (urlBuilder: UrlBuilder, options: any) => {
@@ -69,7 +69,7 @@ describe("lookupAPI", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("resourceAPI", async () => {
+    it("resourceAPI", async function() {
         const params = {
             hrn: "mocked-hrn",
             api: "mocked-api",
@@ -94,7 +94,7 @@ describe("lookupAPI", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("resourceAPIList", async () => {
+    it("resourceAPIList", async function() {
         const params = {
             hrn: "mocked-hrn",
             region: "mocked-region"

--- a/@here/olp-sdk-dataservice-api/test/MetadataApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/MetadataApi.test.ts
@@ -28,8 +28,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("MetadataApi", () => {
-    it("Should getChanges provide data", async () => {
+describe("MetadataApi", function() {
+    it("Should getChanges provide data", async function() {
         const mockedResponse = {
             partitions: [
                 {
@@ -69,7 +69,7 @@ describe("MetadataApi", () => {
         expect(changes).to.be.equal(mockedResponse);
     });
 
-    it("Should getLayerVersions provide data", async () => {
+    it("Should getLayerVersions provide data", async function() {
         const mockedResponse = {
             layerVersions: [
                 {
@@ -103,7 +103,7 @@ describe("MetadataApi", () => {
         expect(versions.version).to.be.equal(mockedResponse.version);
     });
 
-    it("Should getPartitions provide data", async () => {
+    it("Should getPartitions provide data", async function() {
         const mockedResponse = {
             partitions: [
                 {
@@ -142,7 +142,7 @@ describe("MetadataApi", () => {
         expect(changes).to.be.equal(mockedResponse);
     });
 
-    it("Should latestVersion provide data", async () => {
+    it("Should latestVersion provide data", async function() {
         const mockedStartedVersion = 1;
         const mockedResponse = {
             version: 42
@@ -166,7 +166,7 @@ describe("MetadataApi", () => {
         expect(version.version).to.be.equal(mockedResponse.version);
     });
 
-    it("Should listVersions provide data", async () => {
+    it("Should listVersions provide data", async function() {
         const mockedStartedVersion = 1;
         const mockedEndVersion = 42;
         const mockedResponse = {
@@ -202,7 +202,7 @@ describe("MetadataApi", () => {
         expect(versions).to.be.equal(mockedResponse);
     });
 
-    it("Should minimumVersion provide data", async () => {
+    it("Should minimumVersion provide data", async function() {
         const mockedResponse = {
             version: 42
         };

--- a/@here/olp-sdk-dataservice-api/test/PublishApiV2.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/PublishApiV2.test.ts
@@ -28,8 +28,8 @@ chai.use(sinonChai);
 
 const expect = chai.expect;
 
-describe("PublishApi", () => {
-    it("getPublication", async () => {
+describe("PublishApi", function() {
+    it("getPublication", async function() {
         const params = {
             publicationId: "mocked-publicationId",
             billingTag: "mocked-billingTag"
@@ -52,7 +52,7 @@ describe("PublishApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("initPublication", async () => {
+    it("initPublication", async function() {
         const params = {
             publicationId: "mocked-publicationId",
             body: {
@@ -87,7 +87,7 @@ describe("PublishApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("submitPublication", async () => {
+    it("submitPublication", async function() {
         const params = {
             publicationId: "mocked-publicationId",
             billingTag: "mocked-billingTag"
@@ -113,7 +113,7 @@ describe("PublishApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("uploadPartitions", async () => {
+    it("uploadPartitions", async function() {
         const params = {
             layerId: "mocked-layer-id",
             publicationId: "mocked-publicationId",
@@ -152,7 +152,7 @@ describe("PublishApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("cancelPublication", async () => {
+    it("cancelPublication", async function() {
         const params = {
             publicationId: "mocked-publicationId",
             billingTag: "mocked-billingTag"

--- a/@here/olp-sdk-dataservice-api/test/QuetyApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/QuetyApi.test.ts
@@ -27,8 +27,8 @@ chai.use(sinonChai);
 
 const expect = chai.expect;
 
-describe("QueryApi", () => {
-    it("getChangesById", async () => {
+describe("QueryApi", function() {
+    it("getChangesById", async function() {
         const params = {
             layerId: "mocked-layerId",
             startVersion: "mocked-startVersion",
@@ -56,7 +56,7 @@ describe("QueryApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getPartitionsById", async () => {
+    it("getPartitionsById", async function() {
         const params = {
             layerId: "mocked-layerId",
             partition: ["mocked-partition-1", "mocked-partition-2"],
@@ -82,7 +82,7 @@ describe("QueryApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("quadTreeIndex", async () => {
+    it("quadTreeIndex", async function() {
         const params = {
             layerId: "mocked-layerId",
             version: 124,
@@ -112,7 +112,7 @@ describe("QueryApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("quadTreeIndexVolatile", async () => {
+    it("quadTreeIndexVolatile", async function() {
         const params = {
             layerId: "mocked-layerId",
             quadKey: "mocked-quadKey",

--- a/@here/olp-sdk-dataservice-api/test/RequestBuilder.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/RequestBuilder.test.ts
@@ -23,15 +23,15 @@ import { UrlBuilder } from "../index";
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("UrlBuilderTest", () => {
+describe("UrlBuilderTest", function() {
     const testUrlBuilder = new UrlBuilder("test-url");
 
-    it("UrlBuilder shoud be initialized", async () => {
+    it("UrlBuilder shoud be initialized", async function() {
         assert.isDefined(testUrlBuilder);
         expect(testUrlBuilder).to.be.instanceOf(UrlBuilder);
     });
 
-    it("Method stringifyQuery should return URL query string from a key, value paris provided as params.", async () => {
+    it("Method stringifyQuery should return URL query string from a key, value paris provided as params.", async function() {
         const mockedUrlQueryResult = "testKey=testValuetestKey2=testValue2";
 
         const urlQueryResult = UrlBuilder.stringifyQuery({
@@ -41,7 +41,7 @@ describe("UrlBuilderTest", () => {
         expect(urlQueryResult).to.be.equal(mockedUrlQueryResult);
     });
 
-    it("Method appendQuery should appends parameters key, value to the URL.", async () => {
+    it("Method appendQuery should appends parameters key, value to the URL.", async function() {
         const mockedUrl = "test-url?testKey=testValue";
 
         testUrlBuilder.appendQuery("testKey", "testValue");
@@ -51,7 +51,7 @@ describe("UrlBuilderTest", () => {
         expect(testUrlBuilder.hasQuery).to.be.equal(true);
     });
 
-    it("Method appendQuery should not appends parameters to the URL if value is undefined.", async () => {
+    it("Method appendQuery should not appends parameters to the URL if value is undefined.", async function() {
         const testUrlBuilder2 = new UrlBuilder("test-url");
         const mockedUrl = "test-url";
 
@@ -63,7 +63,7 @@ describe("UrlBuilderTest", () => {
         expect(testUrlBuilder2.hasQuery).to.be.equal(false);
     });
 
-    it("Method appendQuery should appends parameters key, value to the URL, when parameter value type is number", async () => {
+    it("Method appendQuery should appends parameters key, value to the URL, when parameter value type is number", async function() {
         const testUrlBuilder3 = new UrlBuilder("test-url");
         const mockedValue = 33;
         const mockedUrl = "test-url?testKey3=33";
@@ -76,7 +76,7 @@ describe("UrlBuilderTest", () => {
         expect(testUrlBuilder3.hasQuery).to.be.equal(true);
     });
 
-    it("Method appendQuery should appends parameters key, value to the URL, when parameter value is an array of strings", async () => {
+    it("Method appendQuery should appends parameters key, value to the URL, when parameter value is an array of strings", async function() {
         const testUrlBuilder4 = new UrlBuilder("test-url");
         const mockedUrl = "test-url?testkey=value1,value2,value3";
 

--- a/@here/olp-sdk-dataservice-api/test/StreamApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/StreamApi.test.ts
@@ -27,8 +27,8 @@ chai.use(sinonChai);
 
 const expect = chai.expect;
 
-describe("StreamApi", () => {
-    it("Should commitOffsets works as expected", async () => {
+describe("StreamApi", function() {
+    it("Should commitOffsets works as expected", async function() {
         const builder = {
             baseUrl: "http://mocked.url",
             request: async (urlBuilder: UrlBuilder, options: any) => {
@@ -56,7 +56,7 @@ describe("StreamApi", () => {
         });
     });
 
-    it("Should doCommitOffsets works as expected", async () => {
+    it("Should doCommitOffsets works as expected", async function() {
         const builder = {
             baseUrl: "http://mocked.url",
             requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
@@ -84,7 +84,7 @@ describe("StreamApi", () => {
         });
     });
 
-    it("Should subscribe works as expected", async () => {
+    it("Should subscribe works as expected", async function() {
         const builder = ({
             baseUrl: "http://mocked.url",
             requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
@@ -108,7 +108,7 @@ describe("StreamApi", () => {
         });
     });
 
-    it("Should consumeData works as expected", async () => {
+    it("Should consumeData works as expected", async function() {
         const builder = ({
             baseUrl: "http://mocked.url",
             requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
@@ -128,7 +128,7 @@ describe("StreamApi", () => {
         });
     });
 
-    it("Should seekToOffset works as expected", async () => {
+    it("Should seekToOffset works as expected", async function() {
         const builder = ({
             baseUrl: "http://mocked.url",
             requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
@@ -156,7 +156,7 @@ describe("StreamApi", () => {
         });
     });
 
-    it("Should deleteSubscription works as expected", async () => {
+    it("Should deleteSubscription works as expected", async function() {
         const builder = {
             baseUrl: "http://mocked.url",
             requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
@@ -176,7 +176,7 @@ describe("StreamApi", () => {
         });
     });
 
-    it("Should endpoint works as expected", async () => {
+    it("Should endpoint works as expected", async function() {
         const builder = {
             baseUrl: "http://mocked.url",
             request: async (urlBuilder: UrlBuilder, options: any) => {
@@ -193,7 +193,7 @@ describe("StreamApi", () => {
         });
     });
 
-    it("Should endpointByConsumer works as expected", async () => {
+    it("Should endpointByConsumer works as expected", async function() {
         const builder = {
             baseUrl: "http://mocked.url",
             request: async (urlBuilder: UrlBuilder, options: any) => {

--- a/@here/olp-sdk-dataservice-api/test/VolatileBlobApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/VolatileBlobApi.test.ts
@@ -28,8 +28,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("VolatileBlobApi", () => {
-    it("checkHandleExists", async () => {
+describe("VolatileBlobApi", function() {
+    it("checkHandleExists", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -53,7 +53,7 @@ describe("VolatileBlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("deleteVolatileBlob", async () => {
+    it("deleteVolatileBlob", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -77,7 +77,7 @@ describe("VolatileBlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("getVolatileBlob", async () => {
+    it("getVolatileBlob", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",
@@ -101,7 +101,7 @@ describe("VolatileBlobApi", () => {
         expect(result).to.be.equal("success");
     });
 
-    it("putVolatileBlob", async () => {
+    it("putVolatileBlob", async function() {
         const params = {
             layerId: "mocked-id",
             dataHandle: "mocked-datahandle",

--- a/@here/olp-sdk-dataservice-api/tslint.json
+++ b/@here/olp-sdk-dataservice-api/tslint.json
@@ -112,7 +112,7 @@
       "check-whitespace"
     ],
     "only-arrow-functions": [
-      true,
+      false,
       "allow-declarations",
       "allow-named-functions"
     ],

--- a/@here/olp-sdk-dataservice-read/test/unit/ArtifactClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/ArtifactClient.test.ts
@@ -30,7 +30,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("ArtifactClient", () => {
+describe("ArtifactClient", function() {
     let sandbox: sinon.SinonSandbox;
     let olpClientSettingsStub: sinon.SinonStubbedInstance<dataServiceRead.OlpClientSettings>;
     let getArtifactUsingGETStub: sinon.SinonStub;
@@ -42,11 +42,11 @@ describe("ArtifactClient", () => {
     const mockedLayerId = "mocked-layed-id";
     const fakeURL = "http://fake-base.url";
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         olpClientSettingsStub = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
         );
@@ -63,18 +63,18 @@ describe("ArtifactClient", () => {
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Shoud be initialised with settings", async () => {
+    it("Shoud be initialised with settings", async function() {
         const artifactClient = new dataServiceRead.ArtifactClient(
             olpClientSettingsStub as any
         );
         assert.isDefined(artifactClient);
     });
 
-    it("Should method getSchema provide data", async () => {
+    it("Should method getSchema provide data", async function() {
         const mockedSchema: Response = new Response(null, {
             statusText: "mocked response"
         });
@@ -100,7 +100,7 @@ describe("ArtifactClient", () => {
         assert.isDefined(response);
     });
 
-    it("Should method getSchema return HttpError when ArtifactClient API crashes", async () => {
+    it("Should method getSchema return HttpError when ArtifactClient API crashes", async function() {
         const NOT_FOUND_ERROR_CODE = 404;
         const mockedError = new HttpError(NOT_FOUND_ERROR_CODE, "Not found");
 
@@ -134,7 +134,7 @@ describe("ArtifactClient", () => {
             });
     });
 
-    it("Should method getSchema return error without variant data provided", async () => {
+    it("Should method getSchema return error without variant data provided", async function() {
         const mockedError: string =
             "Please provide the schema variant by schemaRequest.withVariant()";
 
@@ -153,7 +153,7 @@ describe("ArtifactClient", () => {
             });
     });
 
-    it("Should method getSchemaDetails provide data", async () => {
+    it("Should method getSchemaDetails provide data", async function() {
         const mockedSchema: ArtifactApi.GetSchemaResponse = {
             variants: [
                 {
@@ -186,7 +186,7 @@ describe("ArtifactClient", () => {
         expect(mockedSchema).be.equal(response);
     });
 
-    it("Should method getSchemaDetails return HttpError when ArtifactClient crashes", async () => {
+    it("Should method getSchemaDetails return HttpError when ArtifactClient crashes", async function() {
         const NOT_FOUND_ERROR_CODE = 404;
         const mockedError = new HttpError(NOT_FOUND_ERROR_CODE, "Not found");
 
@@ -226,7 +226,7 @@ describe("ArtifactClient", () => {
             });
     });
 
-    it("Should method getSchemaDetails return error without hrn provided", async () => {
+    it("Should method getSchemaDetails return error without hrn provided", async function() {
         const mockedError: string =
             "Please provide the schema HRN by schemaDetailsRequest.withSchema()";
 

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
@@ -37,7 +37,7 @@ class MockCatalogVersionRequest {
     }
 }
 
-describe("CatalogClient", () => {
+describe("CatalogClient", function() {
     let sandbox: sinon.SinonSandbox;
     let getVersionStub: sinon.SinonStub;
     let getLayerVersionsStub: sinon.SinonStub;
@@ -51,7 +51,7 @@ describe("CatalogClient", () => {
         "hrn:here:data:::live-weather-na"
     );
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
         let settings = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
@@ -62,7 +62,7 @@ describe("CatalogClient", () => {
         );
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         getVersionStub = sandbox.stub(MetadataApi, "latestVersion");
         getLayerVersionsStub = sandbox.stub(MetadataApi, "getLayerVersions");
         getCatalogStub = sandbox.stub(ConfigApi, "getCatalog");
@@ -75,15 +75,15 @@ describe("CatalogClient", () => {
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Shoud be initialised", async () => {
+    it("Shoud be initialised", async function() {
         assert.isDefined(catalogClient);
     });
 
-    it("Should method getLatestVersion provide data with startVersion parameter", async () => {
+    it("Should method getLatestVersion provide data with startVersion parameter", async function() {
         const mockedVersion = {
             version: 42
         };
@@ -109,7 +109,7 @@ describe("CatalogClient", () => {
         expect(response).to.be.equal(mockedVersion.version);
     });
 
-    it("Should method getLatestVersion return HttpError when API crashes", async () => {
+    it("Should method getLatestVersion return HttpError when API crashes", async function() {
         const TEST_ERROR_CODE = 404;
         const mockedError = new HttpError(
             TEST_ERROR_CODE,
@@ -147,7 +147,7 @@ describe("CatalogClient", () => {
             });
     });
 
-    it("Should method getLayerVersions return HttpError when MetadataApi.getLayerVersions crashes", async () => {
+    it("Should method getLayerVersions return HttpError when MetadataApi.getLayerVersions crashes", async function() {
         const testError = "Can not get catalog layer version";
 
         getLayerVersionsStub.callsFake(
@@ -169,7 +169,7 @@ describe("CatalogClient", () => {
             });
     });
 
-    it("Should method getLayerVersions provide data with version parameter", async () => {
+    it("Should method getLayerVersions provide data with version parameter", async function() {
         const mockedVersion = {
             layerVersions: [
                 { layer: "testLayer1", version: 1, timestamp: 11 },
@@ -196,7 +196,7 @@ describe("CatalogClient", () => {
         expect(response).to.be.equal(mockedVersion.layerVersions);
     });
 
-    it("Should method getLayerVersions provide data for latests version when version parameter is not setted", async () => {
+    it("Should method getLayerVersions provide data for latests version when version parameter is not setted", async function() {
         const mockedLayerVersions = {
             layerVersions: [
                 { layer: "testLayer1", version: 1, timestamp: 11 },
@@ -233,7 +233,7 @@ describe("CatalogClient", () => {
         expect(response).to.be.equal(mockedLayerVersions.layerVersions);
     });
 
-    it("Should method getEarliestVersion provide the minimun version availiable for the given catalogRequest", async () => {
+    it("Should method getEarliestVersion provide the minimun version availiable for the given catalogRequest", async function() {
         const mockedEarliestVersion: MetadataApi.VersionResponse = {
             version: 5
         };
@@ -256,7 +256,7 @@ describe("CatalogClient", () => {
         expect(response).to.be.equal(mockedEarliestVersion.version);
     });
 
-    it("Should method getEarliestVersion return HttpError getting earliest catalog version", async () => {
+    it("Should method getEarliestVersion return HttpError getting earliest catalog version", async function() {
         const TEST_ERROR_CODE = 404;
         const mockedError = new HttpError(
             TEST_ERROR_CODE,
@@ -288,7 +288,7 @@ describe("CatalogClient", () => {
             });
     });
 
-    it("Should method getCatalog provide data", async () => {
+    it("Should method getCatalog provide data", async function() {
         const mockedCatalogResponse: ConfigApi.Catalog = {
             id: "here-internal-test",
             hrn: "hrn:here-dev:data:::here-internal-test",
@@ -328,7 +328,7 @@ describe("CatalogClient", () => {
         expect(response).to.be.equal(mockedCatalogResponse);
     });
 
-    it("Should method getCatalog return HttpError when Can not load catalog configuration", async () => {
+    it("Should method getCatalog return HttpError when Can not load catalog configuration", async function() {
         const TEST_ERROR_CODE = 404;
         const mockedError = new HttpError(
             TEST_ERROR_CODE,
@@ -378,7 +378,7 @@ describe("CatalogClient", () => {
             });
     });
 
-    it("Should method getVersions provide data with startVersion and EndVersion parameters", async () => {
+    it("Should method getVersions provide data with startVersion and EndVersion parameters", async function() {
         const mockedVersions: MetadataApi.VersionInfos = {
             versions: [
                 {
@@ -413,7 +413,7 @@ describe("CatalogClient", () => {
         assert.isTrue(response.versions.length > 0);
     });
 
-    it("Should method getVersions provide data with startVersion parameters", async () => {
+    it("Should method getVersions provide data with startVersion parameters", async function() {
         const mockedVersions = {
             versions: [
                 {
@@ -445,7 +445,7 @@ describe("CatalogClient", () => {
         assert.isTrue(response.versions.length > 0);
     });
 
-    it("Should method getVersions return HttpError when API crashes", async () => {
+    it("Should method getVersions return HttpError when API crashes", async function() {
         const TEST_ERROR_CODE = 404;
         const mockedError = new HttpError(
             TEST_ERROR_CODE,

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogRequest.test.ts
@@ -28,20 +28,24 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CatalogRequest", () => {
+describe("CatalogRequest", function() {
     const billingTag = "billingTag";
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const catalogRequest = new CatalogRequest();
 
         assert.isDefined(CatalogRequest);
         expect(catalogRequest).be.instanceOf(CatalogRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const catalogRequest = new CatalogRequest();
-        const catalogRequestWithBillTag = catalogRequest.withBillingTag(billingTag);
+        const catalogRequestWithBillTag = catalogRequest.withBillingTag(
+            billingTag
+        );
 
-        expect(catalogRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
+        expect(catalogRequestWithBillTag.getBillingTag()).to.be.equal(
+            billingTag
+        );
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogVersionRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogVersionRequest.test.ts
@@ -28,38 +28,48 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CatalogVersionRequest", () => {
+describe("CatalogVersionRequest", function() {
     const billingTag = "billingTag";
     const mockedStartVersion = 13;
     const mockedEndVersion = 42;
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const catalogVersionRequest = new CatalogVersionRequest();
 
         assert.isDefined(catalogVersionRequest);
         expect(catalogVersionRequest).be.instanceOf(CatalogVersionRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const catalogVersionRequest = new CatalogVersionRequest();
 
-        const catalogStartVersion = catalogVersionRequest.withStartVersion(mockedStartVersion);
-        const catalogEndVersion = catalogVersionRequest.withEndVersion(mockedEndVersion);
+        const catalogStartVersion = catalogVersionRequest.withStartVersion(
+            mockedStartVersion
+        );
+        const catalogEndVersion = catalogVersionRequest.withEndVersion(
+            mockedEndVersion
+        );
         const catalogBillTag = catalogVersionRequest.withBillingTag(billingTag);
 
-        expect(catalogStartVersion.getStartVersion()).to.be.equal(mockedStartVersion);
+        expect(catalogStartVersion.getStartVersion()).to.be.equal(
+            mockedStartVersion
+        );
         expect(catalogEndVersion.getEndVersion()).to.be.equal(mockedEndVersion);
         expect(catalogBillTag.getBillingTag()).to.be.equal(billingTag);
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const catalogVersionRequest = new CatalogVersionRequest()
             .withStartVersion(mockedStartVersion)
             .withEndVersion(mockedEndVersion)
             .withBillingTag(billingTag);
 
-        expect(catalogVersionRequest.getStartVersion()).to.be.equal(mockedStartVersion);
-        expect(catalogVersionRequest.getEndVersion()).to.be.equal(mockedEndVersion);
+        expect(catalogVersionRequest.getStartVersion()).to.be.equal(
+            mockedStartVersion
+        );
+        expect(catalogVersionRequest.getEndVersion()).to.be.equal(
+            mockedEndVersion
+        );
         expect(catalogVersionRequest.getBillingTag()).to.be.equal(billingTag);
     });
 });

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogsRequest.test.ts
@@ -28,28 +28,36 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CatalogsRequest", () => {
+describe("CatalogsRequest", function() {
     const billingTag = "billingTag";
     const mockedSchemaHRN1 = "hrn:::test-hrn1";
     const mockedSchemaHRN2 = "hrn:::test-hrn2";
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const catalogsRequest = new CatalogsRequest();
 
         assert.isDefined(catalogsRequest);
         expect(catalogsRequest).be.instanceOf(CatalogsRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const catalogsRequest = new CatalogsRequest();
-        const catalogsRequestWithSchemaHrn = catalogsRequest.withSchema(mockedSchemaHRN1);
-        const catalogsRequestWithBillTag = catalogsRequest.withBillingTag(billingTag);
+        const catalogsRequestWithSchemaHrn = catalogsRequest.withSchema(
+            mockedSchemaHRN1
+        );
+        const catalogsRequestWithBillTag = catalogsRequest.withBillingTag(
+            billingTag
+        );
 
-        expect(catalogsRequestWithSchemaHrn.getSchema()).to.be.equal(mockedSchemaHRN1);
-        expect(catalogsRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
+        expect(catalogsRequestWithSchemaHrn.getSchema()).to.be.equal(
+            mockedSchemaHRN1
+        );
+        expect(catalogsRequestWithBillTag.getBillingTag()).to.be.equal(
+            billingTag
+        );
     });
 
-    it("Should set parameters with chain", () => {
+    it("Should set parameters with chain", function() {
         const catalogsRequest = new CatalogsRequest()
             .withSchema(mockedSchemaHRN1)
             .withSchema(mockedSchemaHRN2)

--- a/@here/olp-sdk-dataservice-read/test/unit/ConfigClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/ConfigClient.test.ts
@@ -30,22 +30,22 @@ let sandbox: sinon.SinonSandbox;
 const settings = {} as any;
 const configClient = new dataServiceRead.ConfigClient(settings);
 
-describe("ConfigClient", () => {
-    before(() => {
+describe("ConfigClient", function() {
+    before(function() {
         sandbox = sinon.createSandbox();
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox
             .stub(dataServiceRead.RequestFactory, "create")
             .callsFake(() => Promise.resolve({} as any));
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Should works as expected with empty request.", async () => {
+    it("Should works as expected with empty request.", async function() {
         class MockedCatalogsRequest {
             public getSchema() {
                 return undefined;
@@ -64,7 +64,7 @@ describe("ConfigClient", () => {
         await configClient.getCatalogs(catalogsConfigRequest as any);
     });
 
-    it("Should works as expected with request with schema and empty billing tag", async () => {
+    it("Should works as expected with request with schema and empty billing tag", async function() {
         class MockedCatalogsRequest {
             public getSchema() {
                 return "test-schema-string";
@@ -85,7 +85,7 @@ describe("ConfigClient", () => {
         await configClient.getCatalogs(catalogsConfigRequest as any);
     });
 
-    it("Should works as expected with request with schema and with billing tag", async () => {
+    it("Should works as expected with request with schema and with billing tag", async function() {
         class MockedCatalogsRequest {
             public getSchema() {
                 return "test-schema-string";

--- a/@here/olp-sdk-dataservice-read/test/unit/DataRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/DataRequest.test.ts
@@ -28,7 +28,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("DataRequest", () => {
+describe("DataRequest", function() {
     const billingTag = "billingTag";
     const mockedDataHandle = "43d76b9f-e934-40e5-9ce4-91d88a30f1c6";
     const mockedPartitionId = "123123123";
@@ -39,29 +39,39 @@ describe("DataRequest", () => {
         level: 42
     };
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const dataRequest = new DataRequest();
 
         assert.isDefined(dataRequest);
         expect(dataRequest).be.instanceOf(DataRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const dataRequest = new DataRequest();
-        const dataRequestWithCatalogHrn = dataRequest.withDataHandle(mockedDataHandle);
-        const dataRequestWithLayerId = dataRequest.withPartitionId(mockedPartitionId);
+        const dataRequestWithCatalogHrn = dataRequest.withDataHandle(
+            mockedDataHandle
+        );
+        const dataRequestWithLayerId = dataRequest.withPartitionId(
+            mockedPartitionId
+        );
         const dataRequestWithDataLevel = dataRequest.withQuadKey(mockedQuadKey);
         const dataRequestWithTimemap = dataRequest.withVersion(mockedVersion);
         const dataRequestWithBillTag = dataRequest.withBillingTag(billingTag);
 
-        expect(dataRequestWithCatalogHrn.getDataHandle()).to.be.equal(mockedDataHandle);
-        expect(dataRequestWithLayerId.getPartitionId()).to.be.equal(mockedPartitionId);
-        expect(dataRequestWithDataLevel.getQuadKey()).to.be.equal(mockedQuadKey);
+        expect(dataRequestWithCatalogHrn.getDataHandle()).to.be.equal(
+            mockedDataHandle
+        );
+        expect(dataRequestWithLayerId.getPartitionId()).to.be.equal(
+            mockedPartitionId
+        );
+        expect(dataRequestWithDataLevel.getQuadKey()).to.be.equal(
+            mockedQuadKey
+        );
         expect(dataRequestWithTimemap.getVersion()).to.be.equal(mockedVersion);
         expect(dataRequestWithBillTag.getBillingTag()).to.be.equal(billingTag);
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const dataRequest = new DataRequest()
             .withDataHandle(mockedDataHandle)
             .withPartitionId(mockedPartitionId)

--- a/@here/olp-sdk-dataservice-read/test/unit/IndexLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/IndexLayerClient.test.ts
@@ -30,7 +30,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("IndexLayerClient", () => {
+describe("IndexLayerClient", function() {
     let sandbox: sinon.SinonSandbox;
     let getBlobStub: sinon.SinonStub;
     let getIndexStub: sinon.SinonStub;
@@ -43,7 +43,7 @@ describe("IndexLayerClient", () => {
     const mockedLayerId = "mocked-layed-id";
     const fakeURL = "http://fake-base.url";
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
         let settings = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
@@ -64,7 +64,7 @@ describe("IndexLayerClient", () => {
         );
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         getBlobStub = sandbox.stub(BlobApi, "getBlob");
         getIndexStub = sandbox.stub(IndexApi, "performQuery");
         getBaseUrlRequestStub = sandbox.stub(
@@ -74,18 +74,18 @@ describe("IndexLayerClient", () => {
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Shoud be initialized", async () => {
+    it("Shoud be initialized", async function() {
         assert.isDefined(indexLayerClient);
         expect(indexLayerClient).be.instanceOf(
             dataServiceRead.IndexLayerClient
         );
     });
 
-    it("Should method getPartitions provide data with IndexQueryRequest", async () => {
+    it("Should method getPartitions provide data with IndexQueryRequest", async function() {
         const mockedIndexResponse = {
             data: [
                 {
@@ -133,7 +133,7 @@ describe("IndexLayerClient", () => {
         expect(partitions).to.be.equal(mockedIndexResponse.data);
     });
 
-    it("Should method getPartitions with IndexQueryRequest return HttpError when IndexApi crashes", async () => {
+    it("Should method getPartitions with IndexQueryRequest return HttpError when IndexApi crashes", async function() {
         const TEST_ERROR_CODE = 404;
         const mockedHttpError = new HttpError(TEST_ERROR_CODE, "Test Error");
 
@@ -156,7 +156,7 @@ describe("IndexLayerClient", () => {
             });
     });
 
-    it("Should method getPartitions return error without IndexQueryRequest", async () => {
+    it("Should method getPartitions return error without IndexQueryRequest", async function() {
         const mockedErrorResponse = {
             message: "Please provide correct query"
         };
@@ -170,7 +170,7 @@ describe("IndexLayerClient", () => {
             });
     });
 
-    it("Should method getPartitions be aborted fetching by abort signal", async () => {
+    it("Should method getPartitions be aborted fetching by abort signal", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedIndexResponse = {
             data: [
@@ -231,7 +231,7 @@ describe("IndexLayerClient", () => {
         abortController.abort();
     });
 
-    it("Should method getData provide data", async () => {
+    it("Should method getData provide data", async function() {
         const mockedBlobData: Response = new Response("mocked-blob-response");
         const mockedModel = {
             id: "8c0e5ac9-b036-4365-8820-dfcba64588fc",
@@ -255,7 +255,7 @@ describe("IndexLayerClient", () => {
         );
     });
 
-    it("Should method getData return Error without parameters", async () => {
+    it("Should method getData return Error without parameters", async function() {
         const mockedErrorResponse = {
             message: "No data handle for this partition"
         };
@@ -266,7 +266,7 @@ describe("IndexLayerClient", () => {
         });
     });
 
-    it("Should error be handled", async () => {
+    it("Should error be handled", async function() {
         const mockedModel = {
             id: "8c0e5ac9-b036-4365-8820-dfcba64588fc",
             size: 111928,
@@ -292,7 +292,7 @@ describe("IndexLayerClient", () => {
             });
     });
 
-    it("Should base url error be handled", async () => {
+    it("Should base url error be handled", async function() {
         const mockedModel = {
             id: "8c0e5ac9-b036-4365-8820-dfcba64588fc",
             size: 111928,
@@ -319,7 +319,7 @@ describe("IndexLayerClient", () => {
             });
     });
 
-    it("Should HttpError be handled", async () => {
+    it("Should HttpError be handled", async function() {
         const TEST_ERROR_CODE = 404;
         const mockedError = new HttpError(TEST_ERROR_CODE, "Test Error");
 
@@ -349,18 +349,18 @@ describe("IndexLayerClient", () => {
             });
     });
 
-    it("IndexLayerClient instance should be initialized with IndexLayerClientParams", async () => {
+    it("IndexLayerClient instance should be initialized with IndexLayerClientParams", async function() {
         assert.isDefined(indexLayerClientNew);
         assert.equal(indexLayerClientNew["hrn"], "hrn:here:data:::mocked-hrn");
     });
 
-    it("IndexLayerClient should throw Error when setted unsuported parameters", async () => {
+    it("IndexLayerClient should throw Error when setted unsuported parameters", async function() {
         let settings1 = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
         );
 
         assert.throws(
-            () => {
+            function() {
                 new dataServiceRead.IndexLayerClient(
                     mockedHRN,
                     "",

--- a/@here/olp-sdk-dataservice-read/test/unit/IndexQueryRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/IndexQueryRequest.test.ts
@@ -28,26 +28,32 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("IndexQueryRequest", () => {
+describe("IndexQueryRequest", function() {
     const mockedQuery = "ingestionTime>1552341200000;";
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const indexQueryRequest = new IndexQueryRequest();
 
         assert.isDefined(indexQueryRequest);
         expect(indexQueryRequest).be.instanceOf(IndexQueryRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const indexQueryRequest = new IndexQueryRequest();
-        const indexQueryRequestWithHuge = indexQueryRequest.withHugeResponse(true);
-        const indexQueryRequestWithQuery = indexQueryRequest.withQueryString(mockedQuery);
+        const indexQueryRequestWithHuge = indexQueryRequest.withHugeResponse(
+            true
+        );
+        const indexQueryRequestWithQuery = indexQueryRequest.withQueryString(
+            mockedQuery
+        );
 
         expect(indexQueryRequestWithHuge.getHugeResponse()).to.be.equal(true);
-        expect(indexQueryRequestWithQuery.getQueryString()).to.be.equal(mockedQuery);
+        expect(indexQueryRequestWithQuery.getQueryString()).to.be.equal(
+            mockedQuery
+        );
     });
 
-    it("Should set parameters with chain", () => {
+    it("Should set parameters with chain", function() {
         const indexQueryRequest = new IndexQueryRequest()
             .withHugeResponse(false)
             .withQueryString(mockedQuery);

--- a/@here/olp-sdk-dataservice-read/test/unit/LayerVersionsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/LayerVersionsRequest.test.ts
@@ -26,19 +26,19 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("LayerVersionsRequest", () => {
+describe("LayerVersionsRequest", function() {
     const billingTag = "billingTag";
     const mockedVersion1 = 5;
     const mockedVersion2 = 6;
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const layerVersionsRequest = new LayerVersionsRequest();
 
         assert.isDefined(layerVersionsRequest);
         expect(layerVersionsRequest).be.instanceOf(LayerVersionsRequest);
     });
 
-    it("Should set version", () => {
+    it("Should set version", function() {
         const layerVersionsRequest = new LayerVersionsRequest();
         const layerVersionsRequestWithVersion = layerVersionsRequest.withVersion(
             mockedVersion1
@@ -55,7 +55,7 @@ describe("LayerVersionsRequest", () => {
         );
     });
 
-    it("Should set version with chain", () => {
+    it("Should set version with chain", function() {
         const layerVersionsRequest = new LayerVersionsRequest()
             .withVersion(mockedVersion1)
             .withVersion(mockedVersion2)

--- a/@here/olp-sdk-dataservice-read/test/unit/PartitionsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/PartitionsRequest.test.ts
@@ -28,7 +28,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("PartitionsRequest", () => {
+describe("PartitionsRequest", function() {
     const billingTag = "billingTag";
     const mockedVersion = 42;
     const mockedIds = ["1", "2", "13", "42"];
@@ -39,14 +39,14 @@ describe("PartitionsRequest", () => {
         "crc"
     ];
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const partitionsRequest = new PartitionsRequest();
 
         assert.isDefined(partitionsRequest);
         expect(partitionsRequest).be.instanceOf(PartitionsRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const partitionsRequest = new PartitionsRequest();
         const partitionsRequestWithVersion = partitionsRequest.withVersion(
             mockedVersion
@@ -73,7 +73,7 @@ describe("PartitionsRequest", () => {
         assert.isDefined(partitionsAdditionalFields.getAdditionalFields());
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const partitionsRequest = new PartitionsRequest()
             .withVersion(mockedVersion)
             .withBillingTag(billingTag)
@@ -91,7 +91,7 @@ describe("PartitionsRequest", () => {
         assert.isDefined(partitionsRequest.getAdditionalFields());
     });
 
-    it("Should be thrown error if additional fields are empty", () => {
+    it("Should be thrown error if additional fields are empty", function() {
         try {
             const partitionsRequest = new PartitionsRequest().withAdditionalFields(
                 []

--- a/@here/olp-sdk-dataservice-read/test/unit/PollRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/PollRequest.test.ts
@@ -27,15 +27,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("PollRequest", () => {
-    it("Should initialize", () => {
+describe("PollRequest", function() {
+    it("Should initialize", function() {
         const pollRequest = new PollRequest();
 
         assert.isDefined(pollRequest);
         expect(pollRequest).be.instanceOf(PollRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const mockMode = "parallel";
         const mockSubId = "1111111111";
 
@@ -47,7 +47,7 @@ describe("PollRequest", () => {
         expect(pollRequestWithSub.getSubscriptionId()).to.be.equal(mockSubId);
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const mockMode = "parallel";
         const mockSubId = "1111111111";
         const pollRequest = new PollRequest()

--- a/@here/olp-sdk-dataservice-read/test/unit/QuadKeyPartitionsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/QuadKeyPartitionsRequest.test.ts
@@ -28,7 +28,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("QuadKeyPartitionsRequest", () => {
+describe("QuadKeyPartitionsRequest", function() {
     const billingTag = "billingTag";
     const mockedVersion = 42;
     const mockedDepth = 3;
@@ -38,7 +38,7 @@ describe("QuadKeyPartitionsRequest", () => {
         level: 3
     };
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const quadKeyPartitionsRequest = new QuadKeyPartitionsRequest();
 
         assert.isDefined(quadKeyPartitionsRequest);
@@ -47,7 +47,7 @@ describe("QuadKeyPartitionsRequest", () => {
         );
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const quadKeyPartitionsRequest = new QuadKeyPartitionsRequest();
         const quadKeyPartitionsRequestWithVersion = quadKeyPartitionsRequest.withVersion(
             mockedVersion
@@ -82,7 +82,7 @@ describe("QuadKeyPartitionsRequest", () => {
         );
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const quadKeyPartitionsRequest = new QuadKeyPartitionsRequest()
             .withVersion(mockedVersion)
             .withDepth(mockedDepth)

--- a/@here/olp-sdk-dataservice-read/test/unit/QuadKeyUtils.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/QuadKeyUtils.test.ts
@@ -20,22 +20,22 @@
 import { assert } from "chai";
 import * as utils from "../../lib/utils/QuadKeyUtils";
 
-describe("QuadKeyUtils", () => {
-    it("Can be constructed from root morton code", () => {
+describe("QuadKeyUtils", function() {
+    it("Can be constructed from root morton code", function() {
         const tile = utils.quadKeyFromMortonCode("0");
         assert.strictEqual(tile.row, 0, "Row mismatch");
         assert.strictEqual(tile.column, 0, "Column mismatch");
         assert.strictEqual(tile.level, 0, "Level mismatch");
     });
 
-    it("Can be constructed from morton code", () => {
+    it("Can be constructed from morton code", function() {
         const tile = utils.quadKeyFromMortonCode("22893");
         assert.strictEqual(tile.row, 38, "Row mismatch");
         assert.strictEqual(tile.column, 91, "Column mismatch");
         assert.strictEqual(tile.level, 7, "Level mismatch");
     });
 
-    it("Check the tile parents", () => {
+    it("Check the tile parents", function() {
         const tile = { row: 3, column: 3, level: 2 };
         const parent_1 = utils.computeParentKey(tile, 1);
         assert.strictEqual(parent_1.row, 1, "Row mismatch");
@@ -51,7 +51,7 @@ describe("QuadKeyUtils", () => {
         assert.strictEqual(parent_3.level, 0, "Level mismatch");
     });
 
-    it("Check the tile parents with delta 4", () => {
+    it("Check the tile parents with delta 4", function() {
         const tile = { row: 3275, column: 8085, level: 13 };
         const parent = utils.computeParentKey(tile, 4);
         assert.strictEqual(parent.row, 204, "Row mismatch");
@@ -59,7 +59,7 @@ describe("QuadKeyUtils", () => {
         assert.strictEqual(parent.level, 9, "Level mismatch");
     });
 
-    it("Subtile can be added to the root tile", () => {
+    it("Subtile can be added to the root tile", function() {
         const rootTile = { row: 1, column: 1, level: 1 };
         const subTile = { row: 38, column: 91, level: 7 };
         const result = utils.addQuadKeys(rootTile, subTile);
@@ -68,7 +68,7 @@ describe("QuadKeyUtils", () => {
         assert.strictEqual(result.level, 8, "Level mismatch");
     });
 
-    it("Tile is not valid if the row/column is out of bounds", () => {
+    it("Tile is not valid if the row/column is out of bounds", function() {
         const invalid_tile_1 = { row: 5, column: 1, level: 1 };
         assert.isFalse(utils.isValid(invalid_tile_1));
 
@@ -82,7 +82,7 @@ describe("QuadKeyUtils", () => {
         assert.isFalse(utils.isValid(invalid_tile_4));
     });
 
-    it("Tile is not valid if the level is out of bounds", () => {
+    it("Tile is not valid if the level is out of bounds", function() {
         const invalid_tile_1 = { row: 0, column: 0, level: -1 };
         assert.isFalse(utils.isValid(invalid_tile_1));
 

--- a/@here/olp-sdk-dataservice-read/test/unit/QuadTreeIndexRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/QuadTreeIndexRequest.test.ts
@@ -28,7 +28,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("QuadTreeIndexRequest", () => {
+describe("QuadTreeIndexRequest", function() {
     const billingTag = "billingTag";
     const mockedHRN = dataServiceRead.HRN.fromString(
         "hrn:here:data:::mocked-hrn"
@@ -43,7 +43,7 @@ describe("QuadTreeIndexRequest", () => {
         level: 3
     };
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const quadTreeRequest = new dataServiceRead.QuadTreeIndexRequest(
             mockedHRN,
             mockedLayerId,
@@ -59,7 +59,7 @@ describe("QuadTreeIndexRequest", () => {
         expect(quadTreeRequest.getLayerType()).to.be.equal(mockedLayerType);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const quadTreeRequest = new dataServiceRead.QuadTreeIndexRequest(
             mockedHRN,
             mockedLayerId,
@@ -90,7 +90,7 @@ describe("QuadTreeIndexRequest", () => {
         assert.isDefined(quadTreeRequest.getAdditionalFields());
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const quadTreeRequest = new dataServiceRead.QuadTreeIndexRequest(
             mockedHRN,
             mockedLayerId,

--- a/@here/olp-sdk-dataservice-read/test/unit/QueryClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/QueryClient.test.ts
@@ -29,7 +29,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("QueryClient", () => {
+describe("QueryClient", function() {
     let sandbox: sinon.SinonSandbox;
     let getVersionStub: sinon.SinonStub;
     let getPartitionsByIdStub: sinon.SinonStub;
@@ -49,11 +49,11 @@ describe("QueryClient", () => {
         level: 3
     };
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         olpClientSettingsStub = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
         );
@@ -71,18 +71,18 @@ describe("QueryClient", () => {
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Shoud be initialised with settings", async () => {
+    it("Shoud be initialised with settings", async function() {
         const queryClient = new dataServiceRead.QueryClient(
             olpClientSettingsStub as any
         );
         assert.isDefined(queryClient);
     });
 
-    it("Should method fetchQuadTreeIndex provide data with all parameters", async () => {
+    it("Should method fetchQuadTreeIndex provide data with all parameters", async function() {
         const mockedQuadKeyTreeData = {
             subQuads: [
                 {
@@ -126,7 +126,7 @@ describe("QueryClient", () => {
         expect(response).to.be.equal(mockedQuadKeyTreeData);
     });
 
-    it("Should method fetchQuadTreeIndex return error if quadKey is not provided", async () => {
+    it("Should method fetchQuadTreeIndex return error if quadKey is not provided", async function() {
         const mockedErrorResponse = "Please provide correct QuadKey";
         const queryClient = new dataServiceRead.QueryClient(
             olpClientSettingsStub as any
@@ -147,7 +147,7 @@ describe("QueryClient", () => {
             });
     });
 
-    it("Should method fetchQuadTreeIndex return error if layerId is not provided", async () => {
+    it("Should method fetchQuadTreeIndex return error if layerId is not provided", async function() {
         const mockedErrorResponse = "Please provide correct Id of the Layer";
         const queryClient = new dataServiceRead.QueryClient(
             olpClientSettingsStub as any
@@ -168,7 +168,7 @@ describe("QueryClient", () => {
             });
     });
 
-    it("Should method fetchQuadTreeIndex return error if catalog version is not provided", async () => {
+    it("Should method fetchQuadTreeIndex return error if catalog version is not provided", async function() {
         const mockedErrorResponse = `Please provide correct catalog version`;
         const queryClient = new dataServiceRead.QueryClient(
             olpClientSettingsStub as any
@@ -198,7 +198,7 @@ describe("QueryClient", () => {
             });
     });
 
-    it("Should method fetchQuadTreeIndex return error if catalog version is not provided", async () => {
+    it("Should method fetchQuadTreeIndex return error if catalog version is not provided", async function() {
         const mockedError = "Unknown error";
         const mockedErrorResponse = `Error getting the last catalog version: ${mockedError}`;
         const queryClient = new dataServiceRead.QueryClient(
@@ -229,7 +229,7 @@ describe("QueryClient", () => {
             });
     });
 
-    it("Should method getPartitionsById provide data with all parameters", async () => {
+    it("Should method getPartitionsById provide data with all parameters", async function() {
         const mockedIds = ["1", "2", "13", "42"];
         const mockedLayerId = "fake-layer-id";
         const mockedHRN = dataServiceRead.HRN.fromString(
@@ -277,7 +277,7 @@ describe("QueryClient", () => {
         expect(response).to.be.equal(mockedPartitionsResponse);
     });
 
-    it("Should method getPartitionsById return error if partitionIds list is not provided", async () => {
+    it("Should method getPartitionsById return error if partitionIds list is not provided", async function() {
         const mockedErrorResponse = "Please provide correct partitionIds list";
         const mockedLayerId = "fake-layer-id";
         const mockedHRN = dataServiceRead.HRN.fromString(

--- a/@here/olp-sdk-dataservice-read/test/unit/SchemaDetailsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SchemaDetailsRequest.test.ts
@@ -28,34 +28,36 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SchemaDetailsRequest", () => {
+describe("SchemaDetailsRequest", function() {
     const billingTag = "billingTag";
     const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const schemaDetailsRequest = new SchemaDetailsRequest();
 
         assert.isDefined(SchemaDetailsRequest);
         expect(schemaDetailsRequest).be.instanceOf(SchemaDetailsRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const schemaDetailsRequest = new SchemaDetailsRequest();
 
-        const schemaDetailsRequestWithSchema = schemaDetailsRequest.withSchema(mockedHRN);
-        const schemaRequestWithBilTag = schemaDetailsRequest.withBillingTag(billingTag);
+        const schemaDetailsRequestWithSchema = schemaDetailsRequest.withSchema(
+            mockedHRN
+        );
+        const schemaRequestWithBilTag = schemaDetailsRequest.withBillingTag(
+            billingTag
+        );
 
         assert.isDefined(schemaDetailsRequestWithSchema);
         assert.isDefined(schemaRequestWithBilTag);
         expect(schemaDetailsRequestWithSchema.getSchema()).to.be.equal(
             mockedHRN
         );
-        expect(schemaRequestWithBilTag.getBillingTag()).to.be.equal(
-            billingTag
-        );
+        expect(schemaRequestWithBilTag.getBillingTag()).to.be.equal(billingTag);
     });
 
-    it("Should set parameters with chain", () => {
+    it("Should set parameters with chain", function() {
         const schemaDetailsRequest = new SchemaDetailsRequest()
             .withSchema(mockedHRN)
             .withBillingTag(billingTag);

--- a/@here/olp-sdk-dataservice-read/test/unit/SchemaRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SchemaRequest.test.ts
@@ -28,39 +28,39 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SchemaRequest", () => {
+describe("SchemaRequest", function() {
     const billingTag = "billingTag";
     const mockedVersion = {
         id: "42",
         url: "http://fake.url"
     };
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const schemaRequest = new SchemaRequest();
 
         assert.isDefined(schemaRequest);
         expect(schemaRequest).be.instanceOf(SchemaRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const schemaRequest = new SchemaRequest();
 
         const schemaRequestWithVariant = schemaRequest.withVariant(
             mockedVersion
         );
-        const schemaRequestWithBilTag = schemaRequest.withBillingTag(billingTag);
+        const schemaRequestWithBilTag = schemaRequest.withBillingTag(
+            billingTag
+        );
 
         assert.isDefined(schemaRequestWithVariant);
         assert.isDefined(schemaRequestWithBilTag);
         expect(schemaRequestWithVariant.getVariant()).to.be.equal(
             mockedVersion
         );
-        expect(schemaRequestWithBilTag.getBillingTag()).to.be.equal(
-            billingTag
-        );
+        expect(schemaRequestWithBilTag.getBillingTag()).to.be.equal(billingTag);
     });
 
-    it("Should set parameters with chain", () => {
+    it("Should set parameters with chain", function() {
         const schemaRequest = new SchemaRequest()
             .withVariant(mockedVersion)
             .withBillingTag(billingTag);

--- a/@here/olp-sdk-dataservice-read/test/unit/SeekRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SeekRequest.test.ts
@@ -27,15 +27,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SubscribeRequest", () => {
-    it("Should initialize", () => {
+describe("SubscribeRequest", function() {
+    it("Should initialize", function() {
         const seekRequest = new SeekRequest();
 
         assert.isDefined(seekRequest);
         expect(seekRequest).be.instanceOf(SeekRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const mockMode = "parallel";
         const mockSubId = "1111111111";
         const mockOffsets = {
@@ -63,7 +63,7 @@ describe("SubscribeRequest", () => {
         );
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const mockMode = "parallel";
         const mockSubId = "1111111111";
         const mockOffsets = {

--- a/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
@@ -28,7 +28,7 @@ chai.use(sinonChai);
 
 const assert = chai.assert;
 
-describe("StatistiscClient", () => {
+describe("StatistiscClient", function() {
     let sandbox: sinon.SinonSandbox;
     let olpClientSettingsStub: sinon.SinonStubbedInstance<dataServiceRead.OlpClientSettings>;
     let getDataCoverageSummaryStub: sinon.SinonStub;
@@ -42,11 +42,11 @@ describe("StatistiscClient", () => {
     const mockedLayerId = "mocked-layed-id";
     const fakeURL = "http://fake-base.url";
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         olpClientSettingsStub = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
         );
@@ -74,18 +74,18 @@ describe("StatistiscClient", () => {
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Shoud be initialised with context", async () => {
+    it("Shoud be initialised with context", async function() {
         const statisticsClient = new dataServiceRead.StatisticsClient(
             olpClientSettingsStub as any
         );
         assert.isDefined(statisticsClient);
     });
 
-    it("Should method getSummary provide data", async () => {
+    it("Should method getSummary provide data", async function() {
         const mockedSummary: CoverageApi.LayerSummary = {
             catalogHRN: "hrn:here:data:::mocked-hrn",
             layer: mockedLayerId,
@@ -125,7 +125,7 @@ describe("StatistiscClient", () => {
         assert.isDefined(summary);
     });
 
-    it("Should method getSummary return error if catalogHRN is not provided", async () => {
+    it("Should method getSummary return error if catalogHRN is not provided", async function() {
         const mockedErrorResponse = "No catalogHrn provided";
         const statisticsClient = new dataServiceRead.StatisticsClient(
             olpClientSettingsStub as any
@@ -144,7 +144,7 @@ describe("StatistiscClient", () => {
             });
     });
 
-    it("Should method getSummary return error if layerId is not provided", async () => {
+    it("Should method getSummary return error if layerId is not provided", async function() {
         const mockedErrorResponse = "No layerId provided";
         const statisticsClient = new dataServiceRead.StatisticsClient(
             olpClientSettingsStub as any
@@ -163,7 +163,7 @@ describe("StatistiscClient", () => {
             });
     });
 
-    it("Should method getStatistics provide data", async () => {
+    it("Should method getStatistics provide data", async function() {
         const mockedStatistics: Response = new Response("mocked-response");
         const statisticsClient = new dataServiceRead.StatisticsClient(
             olpClientSettingsStub as any
@@ -219,7 +219,7 @@ describe("StatistiscClient", () => {
         assert.isDefined(statisticTimeMap);
     });
 
-    it("Should method getStatistics return error if catalogHRN is not provided", async () => {
+    it("Should method getStatistics return error if catalogHRN is not provided", async function() {
         const mockedErrorResponse = "No catalogHrn provided";
         const statisticsClient = new dataServiceRead.StatisticsClient(
             olpClientSettingsStub as any
@@ -239,7 +239,7 @@ describe("StatistiscClient", () => {
             });
     });
 
-    it("Should method getStatistics return error if layerId is not provided", async () => {
+    it("Should method getStatistics return error if layerId is not provided", async function() {
         const mockedErrorResponse = "No layerId provided";
         const statisticsClient = new dataServiceRead.StatisticsClient(
             olpClientSettingsStub as any
@@ -259,7 +259,7 @@ describe("StatistiscClient", () => {
             });
     });
 
-    it("Should method getStatistics return error if typemap is not provided", async () => {
+    it("Should method getStatistics return error if typemap is not provided", async function() {
         const mockedErrorResponse = "No typemap provided";
         const statisticsClient = new dataServiceRead.StatisticsClient(
             olpClientSettingsStub as any
@@ -279,7 +279,7 @@ describe("StatistiscClient", () => {
             });
     });
 
-    it("Should method getStatistics provide data if dataLevel not set", async () => {
+    it("Should method getStatistics provide data if dataLevel not set", async function() {
         const mockedStatistics: Response = new Response("mocked-response");
         const statisticsClient = new dataServiceRead.StatisticsClient(
             olpClientSettingsStub as any

--- a/@here/olp-sdk-dataservice-read/test/unit/StatisticsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StatisticsRequest.test.ts
@@ -28,21 +28,21 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SummaryRequest", () => {
+describe("SummaryRequest", function() {
     const billingTag = "billingTag";
     const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
     const mockedLayerId = "mocked-layed-id";
     const mockedDataLevel = 9;
     const mockedTimemap = CoverageDataType.TIMEMAP;
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const statisticsRequest = new StatisticsRequest();
 
         assert.isDefined(statisticsRequest);
         expect(statisticsRequest).be.instanceOf(StatisticsRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const statisticsRequest = new StatisticsRequest();
         const statisticsRequestWithCatalogHrn = statisticsRequest.withCatalogHrn(
             mockedHRN
@@ -77,7 +77,7 @@ describe("SummaryRequest", () => {
         );
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const statisticsRequest = new StatisticsRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)

--- a/@here/olp-sdk-dataservice-read/test/unit/StreamLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StreamLayerClient.test.ts
@@ -60,7 +60,7 @@ class StreamLayerClientTest extends dataServiceRead.StreamLayerClient {
     }
 }
 
-describe("StreamLayerClient", () => {
+describe("StreamLayerClient", function() {
     let sandbox: sinon.SinonSandbox;
     let getBaseUrlRequestStub: sinon.SinonStub;
     let getFactoryRequestStub: sinon.SinonStub;
@@ -84,7 +84,7 @@ describe("StreamLayerClient", () => {
         settings: dataServiceRead.OlpClientSettings;
     };
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
         settings = (sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
@@ -97,7 +97,7 @@ describe("StreamLayerClient", () => {
         streamLayerClient = new StreamLayerClientTest(params);
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         getBlobStub = sandbox.stub(BlobApi, "getBlob");
         subscribeStub = sandbox.stub(StreamApi, "subscribe");
         pollStub = sandbox.stub(StreamApi, "consumeData");
@@ -111,11 +111,11 @@ describe("StreamLayerClient", () => {
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Shoud be initialized", async () => {
+    it("Shoud be initialized", async function() {
         assert.isDefined(streamLayerClient);
         expect(streamLayerClient).be.instanceOf(
             dataServiceRead.StreamLayerClient
@@ -127,7 +127,7 @@ describe("StreamLayerClient", () => {
         );
     });
 
-    it("Should subscribe method post data and return subscription id", async () => {
+    it("Should subscribe method post data and return subscription id", async function() {
         const headers = new Headers();
         headers.append("X-Correlation-Id", "9141392.f96875c-9422-4df4-b5ff");
         const mockResponse = {
@@ -154,7 +154,7 @@ describe("StreamLayerClient", () => {
         expect(subscription).to.be.equal(mockResponse.subscriptionId);
     });
 
-    it("Should subscribe be aborted fetching by abort signal", async () => {
+    it("Should subscribe be aborted fetching by abort signal", async function() {
         const mockResponse = {
             nodeBaseURL: "https://mock-url/hrn/id",
             subscriptionId: "-9141392.f96875c-9422-4df4-b5ff-41a4f459"
@@ -189,13 +189,13 @@ describe("StreamLayerClient", () => {
         abortController.abort();
     });
 
-    it("Should poll method get data, post offsets and return messages", async () => {
+    it("Should poll method get data, post offsets and return messages", async function() {
         const headers = new Headers();
         const commitOffsetsResponse = new Response("Ok");
         headers.append("X-Correlation-Id", "9141392.f96875c-9422-4df4-bdfj");
         const mockResponse = ({
             headers,
-            json: () => {
+            json: function() {
                 return {
                     messages: [
                         {
@@ -266,7 +266,7 @@ describe("StreamLayerClient", () => {
         expect(messages[0].metaData.dataSize).to.be.equal(100500);
     });
 
-    it("Should method getData call API with correct arguments", async () => {
+    it("Should method getData call API with correct arguments", async function() {
         const mockedBlobData: Response = new Response("mocked-blob-response");
         const mockedMessage = {
             metaData: {
@@ -296,7 +296,7 @@ describe("StreamLayerClient", () => {
         );
     });
 
-    it("Should base url error be handled", async () => {
+    it("Should base url error be handled", async function() {
         const mockedMessage = {
             metaData: {
                 partition: "314010583",
@@ -328,7 +328,7 @@ describe("StreamLayerClient", () => {
         });
     });
 
-    it("Should method getData return Error without parameters", async () => {
+    it("Should method getData return Error without parameters", async function() {
         const mockedMessage = {
             metaData: {
                 partition: "314010583"
@@ -349,7 +349,7 @@ describe("StreamLayerClient", () => {
         });
     });
 
-    it("Should error be handled", async () => {
+    it("Should error be handled", async function() {
         const mockedMessage = {
             metaData: {
                 partition: "314010583",
@@ -383,7 +383,7 @@ describe("StreamLayerClient", () => {
             });
     });
 
-    it("Should HttpError be handled", async () => {
+    it("Should HttpError be handled", async function() {
         const TEST_ERROR_CODE = 404;
         const mockedError = new HttpError(TEST_ERROR_CODE, "Test Error");
 
@@ -420,7 +420,7 @@ describe("StreamLayerClient", () => {
             });
     });
 
-    it("Should unsubscribe be aborted fetching by abort signal", async () => {
+    it("Should unsubscribe be aborted fetching by abort signal", async function() {
         const mockResponse = ({
             status: 200
         } as unknown) as Response;
@@ -450,7 +450,7 @@ describe("StreamLayerClient", () => {
         abortController.abort();
     });
 
-    it("Should unsubscribe delete subscription and return OK", async () => {
+    it("Should unsubscribe delete subscription and return OK", async function() {
         const mockResponse = ({
             status: 200
         } as unknown) as Response;
@@ -472,7 +472,7 @@ describe("StreamLayerClient", () => {
         expect(unsubscription.status).to.be.equal(mockResponse.status);
     });
 
-    it("Should unsubscribe return error if mode is parallel and subscriptionId is missed", async () => {
+    it("Should unsubscribe return error if mode is parallel and subscriptionId is missed", async function() {
         const mockError =
             "Error: for 'parallel' mode 'subscriptionId' is required.";
 
@@ -487,7 +487,7 @@ describe("StreamLayerClient", () => {
             });
     });
 
-    it("Should seek return error if mode is parallel and subscriptionId is missed", async () => {
+    it("Should seek return error if mode is parallel and subscriptionId is missed", async function() {
         const mockOffsets = {
             offsets: [
                 {
@@ -512,7 +512,7 @@ describe("StreamLayerClient", () => {
         });
     });
 
-    it("Should seek return error if offsets are missed", async () => {
+    it("Should seek return error if offsets are missed", async function() {
         const mockError = "Error: offsets are required.";
 
         const request = new dataServiceRead.SeekRequest();
@@ -522,7 +522,7 @@ describe("StreamLayerClient", () => {
         });
     });
 
-    it("Should seek set offsets and return OK", async () => {
+    it("Should seek set offsets and return OK", async function() {
         const headers = new Headers();
         headers.append("X-Correlation-Id", "9141392.f96875c-9422-4df4-bdfj");
         const mockResponse = ({
@@ -562,7 +562,7 @@ describe("StreamLayerClient", () => {
         expect(seek.status).to.be.equal(mockResponse.status);
     });
 
-    it("Should seek update xCorrelationId", async () => {
+    it("Should seek update xCorrelationId", async function() {
         const xCorrelationId = "9141392.f96875c-9422-4df4-bdfj";
         const headers = new Headers();
         headers.append("X-Correlation-Id", xCorrelationId);
@@ -602,7 +602,7 @@ describe("StreamLayerClient", () => {
         expect(streamLayerClient["xCorrelationId"]).equals(xCorrelationId);
     });
 
-    it("Should pull return error if mode is parallel and subscriptionId is missed", async () => {
+    it("Should pull return error if mode is parallel and subscriptionId is missed", async function() {
         await streamLayerClient
             .poll(new dataServiceRead.PollRequest().withMode("parallel"))
             .catch(error => {
@@ -612,7 +612,7 @@ describe("StreamLayerClient", () => {
             });
     });
 
-    it("Should pull return error if subscribtionNodeBaseUrl is missed", async () => {
+    it("Should pull return error if subscribtionNodeBaseUrl is missed", async function() {
         streamLayerClient["subscribtionNodeBaseUrl"] = undefined;
         await streamLayerClient
             .poll(

--- a/@here/olp-sdk-dataservice-read/test/unit/SubscribeRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SubscribeRequest.test.ts
@@ -27,15 +27,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SubscribeRequest", () => {
-    it("Should initialize", () => {
+describe("SubscribeRequest", function() {
+    it("Should initialize", function() {
         const subscriptionRequest = new SubscribeRequest();
 
         assert.isDefined(subscriptionRequest);
         expect(subscriptionRequest).be.instanceOf(SubscribeRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const mockMode = "parallel";
         const mockSubId = "1111111111";
         const mockConsumerId = "123e4567-e89b-12d3-a456-556642440000";
@@ -71,7 +71,7 @@ describe("SubscribeRequest", () => {
         ).to.be.equal(mockSubscriptionProperties);
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const mockMode = "parallel";
         const mockSubId = "1111111111";
         const mockConsumerId = "123e4567-e89b-12d3-a456-556642440000";

--- a/@here/olp-sdk-dataservice-read/test/unit/SummaryRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/SummaryRequest.test.ts
@@ -28,19 +28,19 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SummaryRequest", () => {
+describe("SummaryRequest", function() {
     const billingTag = "billingTag";
     const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
     const mockedLayerId = "mocked-layed-id";
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         const summaryRequest = new SummaryRequest();
 
         assert.isDefined(summaryRequest);
         expect(summaryRequest).be.instanceOf(SummaryRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const summaryRequest = new SummaryRequest();
         const summaryRequestWithCatalogHrn = summaryRequest.withCatalogHrn(
             mockedHRN
@@ -48,7 +48,9 @@ describe("SummaryRequest", () => {
         const summaryRequestWithLAyerId = summaryRequest.withLayerId(
             mockedLayerId
         );
-        const summaryRequestWithBillTag = summaryRequest.withBillingTag(billingTag);
+        const summaryRequestWithBillTag = summaryRequest.withBillingTag(
+            billingTag
+        );
 
         expect(summaryRequestWithCatalogHrn.getCatalogHrn()).to.be.equal(
             mockedHRN.toString()
@@ -61,7 +63,7 @@ describe("SummaryRequest", () => {
         );
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const summaryRequest = new SummaryRequest()
             .withCatalogHrn(mockedHRN)
             .withLayerId(mockedLayerId)

--- a/@here/olp-sdk-dataservice-read/test/unit/TileRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/TileRequest.test.ts
@@ -28,7 +28,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("TileRequest", () => {
+describe("TileRequest", function() {
     const mockedHRN = dataServiceRead.HRN.fromString(
         "hrn:here:data:::mocked-hrn"
     );
@@ -58,12 +58,12 @@ describe("TileRequest", () => {
 
     const request = new dataServiceRead.TileRequest(tileRequestParams);
 
-    it("Should initialize", () => {
+    it("Should initialize", function() {
         assert.isDefined(request);
         expect(request).be.instanceOf(dataServiceRead.TileRequest);
     });
 
-    it("Should get parameters with chain", async () => {
+    it("Should get parameters with chain", async function() {
         request
             .withTileKey(mockedQuadKey)
             .withBillingTag(mockedBillingTag)
@@ -78,7 +78,7 @@ describe("TileRequest", () => {
         expect(await request.getCatalogVersion()).to.be.equal(12);
     });
 
-    it("Should fetch the latest version of catalog", async () => {
+    it("Should fetch the latest version of catalog", async function() {
         // @ts-ignore
         class TileRequestTest extends dataServiceRead.TileRequest {
             constructor(params: dataServiceRead.TileRequestParams) {
@@ -102,7 +102,7 @@ describe("TileRequest", () => {
         expect(version).to.be.equal(32);
     });
 
-    it("Should be rejected with version error", async () => {
+    it("Should be rejected with version error", async function() {
         // @ts-ignore
         class TileRequestTest extends dataServiceRead.TileRequest {
             constructor(params: dataServiceRead.TileRequestParams) {

--- a/@here/olp-sdk-dataservice-read/test/unit/UnsubscribeRequest.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/UnsubscribeRequest.test.ts
@@ -27,15 +27,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SubscribeRequest", () => {
-    it("Should initialize", () => {
+describe("SubscribeRequest", function() {
+    it("Should initialize", function() {
         const request = new UnsubscribeRequest();
 
         assert.isDefined(request);
         expect(request).be.instanceOf(UnsubscribeRequest);
     });
 
-    it("Should set parameters", () => {
+    it("Should set parameters", function() {
         const mockMode = "parallel";
         const mockSubId = "1111111111";
         const request = new UnsubscribeRequest();
@@ -46,7 +46,7 @@ describe("SubscribeRequest", () => {
         expect(requestWithSub.getSubscriptionId()).to.be.equal(mockSubId);
     });
 
-    it("Should get parameters with chain", () => {
+    it("Should get parameters with chain", function() {
         const mockMode = "parallel";
         const mockSubId = "1111111111";
 

--- a/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
@@ -31,7 +31,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("VersionedLayerClient", () => {
+describe("VersionedLayerClient", function() {
     let sandbox: sinon.SinonSandbox;
     let getBlobStub: sinon.SinonStub;
     let getPartitionsStub: sinon.SinonStub;
@@ -68,7 +68,7 @@ describe("VersionedLayerClient", () => {
         ]
     };
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
         let settings = new dataServiceRead.OlpClientSettings({
             environment: "here",
@@ -102,7 +102,7 @@ describe("VersionedLayerClient", () => {
         );
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         getBlobStub = sandbox.stub(BlobApi, "getBlob");
         getPartitionsStub = sandbox.stub(MetadataApi, "getPartitions");
         getPartitionsByIdStub = sandbox.stub(QueryApi, "getPartitionsById");
@@ -116,21 +116,21 @@ describe("VersionedLayerClient", () => {
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Shoud be initialized", async () => {
+    it("Shoud be initialized", async function() {
         assert.isDefined(versionedLayerClient);
     });
 
-    it("VersionedLayerClient should throw Error when setted unsuported parameters", async () => {
+    it("VersionedLayerClient should throw Error when setted unsuported parameters", async function() {
         let settings1 = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
         );
 
         assert.throws(
-            () => {
+            function() {
                 new dataServiceRead.VersionedLayerClient(
                     mockedHRN,
                     "",
@@ -142,7 +142,7 @@ describe("VersionedLayerClient", () => {
         );
     });
 
-    it("VersionedLayerClient instance should be initialized with VersionedLayerClientParams", async () => {
+    it("VersionedLayerClient instance should be initialized with VersionedLayerClientParams", async function() {
         assert.isDefined(versionedLayerClientWithVersion);
         assert.equal(versionedLayerClientWithVersion["version"], 5);
         assert.equal(
@@ -151,7 +151,7 @@ describe("VersionedLayerClient", () => {
         );
     });
 
-    it("Should method getData provide data with dataHandle parameter", async () => {
+    it("Should method getData provide data with dataHandle parameter", async function() {
         const mockedVersion = {
             version: 42
         };
@@ -182,7 +182,7 @@ describe("VersionedLayerClient", () => {
         assert.isTrue(response.ok);
     });
 
-    it("Should method getData provide data with partitionId parameter", async () => {
+    it("Should method getData provide data with partitionId parameter", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedVersion = {
             version: 42
@@ -227,7 +227,7 @@ describe("VersionedLayerClient", () => {
         assert.isTrue(response.ok);
     });
 
-    it("Should method getData provide data with partitionId parameter and version", async () => {
+    it("Should method getData provide data with partitionId parameter and version", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedPartitionsIdData = {
             partitions: [
@@ -261,7 +261,7 @@ describe("VersionedLayerClient", () => {
         assert.isTrue(response.ok);
     });
 
-    it("Should method getData provide data with quadKey", async () => {
+    it("Should method getData provide data with quadKey", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedVersion = {
             version: 42
@@ -313,7 +313,7 @@ describe("VersionedLayerClient", () => {
         assert.isTrue(response.ok);
     });
 
-    it("Should method getData return Error without dataRequest parameters", async () => {
+    it("Should method getData return Error without dataRequest parameters", async function() {
         const mockedErrorResponse =
             "No data provided. Add dataHandle, partitionId or quadKey to the DataRequest object";
         const dataRequest = new dataServiceRead.DataRequest();
@@ -326,7 +326,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    it("Should method getData return Error with correct partitionId and wrong version parameter", async () => {
+    it("Should method getData return Error with correct partitionId and wrong version parameter", async function() {
         const dataRequest = new dataServiceRead.DataRequest()
             .withVersion(100500)
             .withPartitionId("42");
@@ -354,7 +354,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    it("Should method getData with wrong partitionId parameter and version return error", async () => {
+    it("Should method getData with wrong partitionId parameter and version return error", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedErrorResponse =
             "No partition dataHandle for partition 42. HRN: hrn:here:data:::mocked-hrn";
@@ -391,7 +391,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    it("Should method getData return Error with correct quadKey and wrong version parameter", async () => {
+    it("Should method getData return Error with correct quadKey and wrong version parameter", async function() {
         const dataRequest = new dataServiceRead.DataRequest()
             .withVersion(100500)
             .withQuadKey(dataServiceRead.quadKeyFromMortonCode("23618403"));
@@ -419,7 +419,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    it("Should method getData return Error with incorrect quadKey", async () => {
+    it("Should method getData return Error with incorrect quadKey", async function() {
         const errorMessage =
             "No dataHandle for quadKey {column: 15, row: 1, level: 5}. HRN: hrn:here:data:::mocked-hrn";
         const ERROR_STATUS = 204;
@@ -447,7 +447,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    it("Should be aborted fetching by abort signal", async () => {
+    it("Should be aborted fetching by abort signal", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedPartitionsIdData = {
             partitions: [
@@ -492,7 +492,7 @@ describe("VersionedLayerClient", () => {
         abortController.abort();
     });
 
-    it("Should method getPartitions provide data with PartitionsRequest", async () => {
+    it("Should method getPartitions provide data with PartitionsRequest", async function() {
         const mockedVersion = {
             version: 42
         };
@@ -534,7 +534,7 @@ describe("VersionedLayerClient", () => {
         expect(partitions).to.be.equal(mockedPartitions);
     });
 
-    it("Should method getPartitions provide data with PartitionIds list", async () => {
+    it("Should method getPartitions provide data with PartitionIds list", async function() {
         const mockedIds = ["1", "2", "13", "42"];
         const mockedVersion = {
             version: 42
@@ -579,7 +579,7 @@ describe("VersionedLayerClient", () => {
         expect(partitions).to.be.equal(mockedPartitions);
     });
 
-    it("Should layerClient sends a PartitionsRequest for getPartitions with additionalFields params", async () => {
+    it("Should layerClient sends a PartitionsRequest for getPartitions with additionalFields params", async function() {
         const mockedVersion = {
             version: 42
         };
@@ -624,7 +624,7 @@ describe("VersionedLayerClient", () => {
         ).to.be.equal("checksum");
     });
 
-    it("Should layerClient sends a PartitionsRequest for getPartitions with additionalFields params and get cached data", async () => {
+    it("Should layerClient sends a PartitionsRequest for getPartitions with additionalFields params and get cached data", async function() {
         const partitionsRequest = new dataServiceRead.PartitionsRequest().withAdditionalFields(
             ["dataSize", "checksum"]
         );
@@ -641,7 +641,7 @@ describe("VersionedLayerClient", () => {
         );
     });
 
-    it("Should layerClient sends a PartitionsRequest for getPartitions with extra additionalFields params, check cached data and get new metadata", async () => {
+    it("Should layerClient sends a PartitionsRequest for getPartitions with extra additionalFields params, check cached data and get new metadata", async function() {
         const mockedVersion = {
             version: 42
         };
@@ -677,7 +677,7 @@ describe("VersionedLayerClient", () => {
         );
     });
 
-    it("Should method getPartitions return error without QuadKeyPartitionsRequest", async () => {
+    it("Should method getPartitions return error without QuadKeyPartitionsRequest", async function() {
         const mockedErrorResponse = {
             message: "Please provide correct QuadKey"
         };
@@ -691,7 +691,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    it("Should layerClient sends a QuadKeyPartitionsRequest for getPartitions with additionalFields params", async () => {
+    it("Should layerClient sends a QuadKeyPartitionsRequest for getPartitions with additionalFields params", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedVersion = {
             version: 42
@@ -757,7 +757,7 @@ describe("VersionedLayerClient", () => {
         ).to.be.equal("compressedDataSize");
     });
 
-    it("Should baseUrl error be handled", async () => {
+    it("Should baseUrl error be handled", async function() {
         const mockedErrorResponse = "Bad response";
         const dataHandleRequest = new dataServiceRead.DataRequest().withDataHandle(
             "moсked-data-handle"
@@ -801,7 +801,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    it("Should latestVersion error be handled", async () => {
+    it("Should latestVersion error be handled", async function() {
         const mockedErrorResponse = "Bad response";
         const dataPartitionRequest = new dataServiceRead.DataRequest().withPartitionId(
             "mocked-id"
@@ -849,7 +849,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    it("Should getPartitions with quadKey error be handled", async () => {
+    it("Should getPartitions with quadKey error be handled", async function() {
         const mockedErrorResponse = "Bad response";
         const quadRrequest = new dataServiceRead.DataRequest()
             .withQuadKey(dataServiceRead.quadKeyFromMortonCode("23618403"))
@@ -877,7 +877,7 @@ describe("VersionedLayerClient", () => {
             });
     });
 
-    it("Should getPartitions error be handled if error getting latest layer version", async () => {
+    it("Should getPartitions error be handled if error getting latest layer version", async function() {
         getVersionStub.callsFake(() =>
             Promise.reject({
                 status: 400,
@@ -907,7 +907,7 @@ describe("VersionedLayerClient", () => {
         }
     });
 
-    it("Should getData error be handled if error getting latest layer version", async () => {
+    it("Should getData error be handled if error getting latest layer version", async function() {
         getVersionStub.callsFake(() =>
             Promise.reject({
                 status: 400,
@@ -940,7 +940,7 @@ describe("VersionedLayerClient", () => {
         }
     });
 
-    it("Should getPartitions fetch menadata with latest layer version if not defined", async () => {
+    it("Should getPartitions fetch menadata with latest layer version if not defined", async function() {
         getVersionStub.callsFake(() => Promise.resolve({ version: 5 }));
 
         getPartitionsStub.callsFake((builder, params) => {
@@ -963,7 +963,7 @@ describe("VersionedLayerClient", () => {
         } as any);
     });
 
-    it("Should getPartitions fetch menadata with set layer version in constructor", async () => {
+    it("Should getPartitions fetch menadata with set layer version in constructor", async function() {
         getPartitionsStub.callsFake((builder, params) => {
             assert.equal(params.version, 6);
             return Promise.resolve();
@@ -985,7 +985,7 @@ describe("VersionedLayerClient", () => {
         } as any);
     });
 
-    it("Method QueryApi.getPartitionsById should be called with param additionalFields and run getPartitions method with additionalFields", async () => {
+    it("Method QueryApi.getPartitionsById should be called with param additionalFields and run getPartitions method with additionalFields", async function() {
         const QueryClientStub = sandbox.stub(dataServiceRead, "QueryClient");
 
         const mockedPartitions = {
@@ -1034,7 +1034,7 @@ describe("VersionedLayerClient", () => {
     });
 });
 
-describe("VersionedLayerClient with locked version 0 in constructor", () => {
+describe("VersionedLayerClient with locked version 0 in constructor", function() {
     let sandbox: sinon.SinonSandbox;
     let client: dataServiceRead.VersionedLayerClient;
 
@@ -1046,11 +1046,11 @@ describe("VersionedLayerClient with locked version 0 in constructor", () => {
         getToken: () => Promise.resolve("mocked-token")
     });
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         client = new dataServiceRead.VersionedLayerClient({
             settings: mockedSettings,
             catalogHrn: mockedCatalogHRH,
@@ -1059,16 +1059,16 @@ describe("VersionedLayerClient with locked version 0 in constructor", () => {
         });
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Versioned layer should be initialized with 0 version", () => {
+    it("Versioned layer should be initialized with 0 version", function() {
         expect(client !== undefined).to.be.true;
         expect(client["version"]).to.be.equal(0);
     });
 
-    it("Versioned layer should be initialized with undefined version if user set some version < 0 ", () => {
+    it("Versioned layer should be initialized with undefined version if user set some version < 0 ", function() {
         const client = new dataServiceRead.VersionedLayerClient({
             settings: mockedSettings,
             catalogHrn: mockedCatalogHRH,
@@ -1079,7 +1079,7 @@ describe("VersionedLayerClient with locked version 0 in constructor", () => {
         expect(client["version"]).to.be.equal(undefined);
     });
 
-    it("Method getPartitions should call queryClient.fetchQuadTreeIndex with QuadTreeIndexRequest.getVersion() === 0", async () => {
+    it("Method getPartitions should call queryClient.fetchQuadTreeIndex with QuadTreeIndexRequest.getVersion() === 0", async function() {
         const QueryClientStub = sandbox.stub(dataServiceRead, "QueryClient");
 
         class MockedQueryClient {
@@ -1104,7 +1104,7 @@ describe("VersionedLayerClient with locked version 0 in constructor", () => {
         );
     });
 
-    it("Method getData should not change the version of the layer", async () => {
+    it("Method getData should not change the version of the layer", async function() {
         // @ts-ignore
         class VersionedLayerClientTest extends dataServiceRead.VersionedLayerClient {
             constructor(params: dataServiceRead.VersionedLayerClientParams) {
@@ -1135,7 +1135,7 @@ describe("VersionedLayerClient with locked version 0 in constructor", () => {
         expect(client["version"]).to.be.equal(0);
     });
 
-    it("Method getPartitions should call queryClient.getPartitionsById with PartitionsRequest.getVersion() === 0", async () => {
+    it("Method getPartitions should call queryClient.getPartitionsById with PartitionsRequest.getVersion() === 0", async function() {
         const QueryClientStub = sandbox.stub(dataServiceRead, "QueryClient");
 
         class MockedQueryClient {
@@ -1161,7 +1161,7 @@ describe("VersionedLayerClient with locked version 0 in constructor", () => {
         );
     });
 
-    it("Method getPartitions should call MetadataApi.getPartitions with param version === 0", async () => {
+    it("Method getPartitions should call MetadataApi.getPartitions with param version === 0", async function() {
         // @ts-ignore
         class VersionedLayerClientTest extends dataServiceRead.VersionedLayerClient {
             constructor(params: dataServiceRead.VersionedLayerClientParams) {

--- a/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
@@ -34,7 +34,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("VolatileLayerClient", () => {
+describe("VolatileLayerClient", function() {
     let sandbox: sinon.SinonSandbox;
     let getPartitionsStub: sinon.SinonStub;
     let getBlobStub: sinon.SinonStub;
@@ -70,7 +70,7 @@ describe("VolatileLayerClient", () => {
         ]
     };
 
-    before(() => {
+    before(function() {
         sandbox = sinon.createSandbox();
         let settings = new dataServiceRead.OlpClientSettings({
             environment: "here",
@@ -92,7 +92,7 @@ describe("VolatileLayerClient", () => {
         );
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         getBlobStub = sandbox.stub(VolatileBlobApi, "getVolatileBlob");
         getPartitionsStub = sandbox.stub(MetadataApi, "getPartitions");
         getVersionStub = sandbox.stub(MetadataApi, "latestVersion");
@@ -105,15 +105,15 @@ describe("VolatileLayerClient", () => {
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    it("Shoud be initialized", async () => {
+    it("Shoud be initialized", async function() {
         assert.isDefined(volatileLayerClient);
     });
 
-    it("Should method getPartitions provide data with PartitionsRequest", async () => {
+    it("Should method getPartitions provide data with PartitionsRequest", async function() {
         const mockedPartitions = {
             partitions: [
                 {
@@ -143,7 +143,7 @@ describe("VolatileLayerClient", () => {
         expect(partitions).to.be.equal(mockedPartitions);
     });
 
-    it("Should method getPartitions provide data with PartitionIds list", async () => {
+    it("Should method getPartitions provide data with PartitionIds list", async function() {
         const mockedIds = ["1", "2", "13", "42"];
         const mockedPartitions = {
             partitions: [
@@ -176,7 +176,7 @@ describe("VolatileLayerClient", () => {
         expect(partitions).to.be.equal(mockedPartitions);
     });
 
-    it("Should layerClient sends a PartitionsRequest for getPartitions with additionalFields params", async () => {
+    it("Should layerClient sends a PartitionsRequest for getPartitions with additionalFields params", async function() {
         getPartitionsStub.callsFake(
             (builder: any, params: any): Promise<MetadataApi.Partitions> => {
                 return Promise.resolve(mockedPartitionsAddFields);
@@ -200,7 +200,7 @@ describe("VolatileLayerClient", () => {
         ).to.be.equal("checksum");
     });
 
-    it("Should layerClient sends a PartitionsRequest for getPartitions with additionalFields params and get cached data", async () => {
+    it("Should layerClient sends a PartitionsRequest for getPartitions with additionalFields params and get cached data", async function() {
         const partitionsRequest = new dataServiceRead.PartitionsRequest().withAdditionalFields(
             ["dataSize", "checksum"]
         );
@@ -217,7 +217,7 @@ describe("VolatileLayerClient", () => {
         );
     });
 
-    it("Should layerClient sends a PartitionsRequest for getPartitions with extra additionalFields params, check cached data and get new metadata", async () => {
+    it("Should layerClient sends a PartitionsRequest for getPartitions with extra additionalFields params, check cached data and get new metadata", async function() {
         getPartitionsStub.callsFake(
             (builder: any, params: any): Promise<MetadataApi.Partitions> => {
                 return Promise.resolve(mockedPartitionsAddFields);
@@ -240,7 +240,7 @@ describe("VolatileLayerClient", () => {
         );
     });
 
-    it("Should layerClient sends a QuadKeyPartitionsRequest for getPartitions with additionalFields params", async () => {
+    it("Should layerClient sends a QuadKeyPartitionsRequest for getPartitions with additionalFields params", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedVersion = {
             version: 42
@@ -326,7 +326,7 @@ describe("VolatileLayerClient", () => {
         ).to.be.equal("compressedDataSize");
     });
 
-    it("Should method getPartitions return error without QuadKeyPartitionsRequest", async () => {
+    it("Should method getPartitions return error without QuadKeyPartitionsRequest", async function() {
         const mockedErrorResponse = {
             message: "Please provide correct QuadKey"
         };
@@ -340,7 +340,7 @@ describe("VolatileLayerClient", () => {
             });
     });
 
-    it("Should method getData provide data with dataHandle parameter", async () => {
+    it("Should method getData provide data with dataHandle parameter", async function() {
         const mockedBlobData: Response = new Response("mocked-blob-response");
         getBlobStub.callsFake(
             (builder: any, params: any): Promise<Response> => {
@@ -359,7 +359,7 @@ describe("VolatileLayerClient", () => {
         assert.isTrue(response.ok);
     });
 
-    it("Should method getData provide data with partitionId parameter", async () => {
+    it("Should method getData provide data with partitionId parameter", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedPartitionsIdData = {
             partitions: [
@@ -393,7 +393,7 @@ describe("VolatileLayerClient", () => {
         assert.isTrue(response.ok);
     });
 
-    it("Should method getData provide data with quadKey", async () => {
+    it("Should method getData provide data with quadKey", async function() {
         const mockedBlobData = new Response("mocked-blob-response");
         const mockedVersion = {
             version: 42
@@ -462,7 +462,7 @@ describe("VolatileLayerClient", () => {
         assert.isDefined(response);
     });
 
-    it("Should method getData return Error without dataRequest parameters", async () => {
+    it("Should method getData return Error without dataRequest parameters", async function() {
         const mockedErrorResponse = {
             message:
                 "No data provided. Add dataHandle, partitionId or quadKey to the DataRequest object"
@@ -477,7 +477,7 @@ describe("VolatileLayerClient", () => {
             });
     });
 
-    it("Should method getData return Error with correct partitionId and wrong layerId", async () => {
+    it("Should method getData return Error with correct partitionId and wrong layerId", async function() {
         let settings = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
         );
@@ -514,7 +514,7 @@ describe("VolatileLayerClient", () => {
             });
     });
 
-    it("Should method getData return Error with incorrect quadKey", async () => {
+    it("Should method getData return Error with incorrect quadKey", async function() {
         const errorMessage =
             "No dataHandle for quadKey {column: 15, row: 1, level: 5}. HRN: hrn:here:data:::mocked-hrn";
         const ERROR_STATUS = 204;
@@ -554,7 +554,7 @@ describe("VolatileLayerClient", () => {
             });
     });
 
-    it("Should baseUrl error be handled", async () => {
+    it("Should baseUrl error be handled", async function() {
         const mockedErrorResponse = "Bad response";
         const dataRequest = new dataServiceRead.DataRequest().withDataHandle(
             "moсked-data-handle"
@@ -598,7 +598,7 @@ describe("VolatileLayerClient", () => {
             });
     });
 
-    it("Should getPartitions with quadKey error be handled", async () => {
+    it("Should getPartitions with quadKey error be handled", async function() {
         const mockedErrorResponse = "Bad response";
 
         const quadRrequest = new dataServiceRead.DataRequest().withQuadKey(
@@ -619,7 +619,7 @@ describe("VolatileLayerClient", () => {
             });
     });
 
-    it("VolatileLayerClient instance should be initialized with VolatileLayerClientParams", async () => {
+    it("VolatileLayerClient instance should be initialized with VolatileLayerClientParams", async function() {
         assert.isDefined(volatileLayerClientNew);
         assert.equal(
             volatileLayerClientNew["hrn"],
@@ -627,13 +627,13 @@ describe("VolatileLayerClient", () => {
         );
     });
 
-    it("VolatileLayerClient should throw Error when setted unsuported parameters", async () => {
+    it("VolatileLayerClient should throw Error when setted unsuported parameters", async function() {
         let settings1 = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
         );
 
         assert.throws(
-            () => {
+            function() {
                 new dataServiceRead.VolatileLayerClient(
                     mockedHRN,
                     "",
@@ -645,7 +645,7 @@ describe("VolatileLayerClient", () => {
         );
     });
 
-    it("Method QueryApi.getPartitionsById should be called with param additionalFields and run getPartitions method with additionalFields", async () => {
+    it("Method QueryApi.getPartitionsById should be called with param additionalFields and run getPartitions method with additionalFields", async function() {
         const QueryClientStub = sandbox.stub(dataServiceRead, "QueryClient");
 
         const mockedPartitions = {

--- a/@here/olp-sdk-dataservice-read/test/unit/getTile.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/getTile.test.ts
@@ -25,7 +25,7 @@ import {
     HRN
 } from "@here/olp-sdk-dataservice-read/lib";
 
-describe("getTile", () => {
+describe("getTile", function() {
     const settings = new OlpClientSettings({
         environment: "mock-env",
         getToken: () => Promise.resolve("mocked-token"),
@@ -42,7 +42,7 @@ describe("getTile", () => {
         layerType: "versioned"
     });
 
-    it("Should throw an error if not tile key", async () => {
+    it("Should throw an error if not tile key", async function() {
         const tile = await getTile(request).catch(err => err.message);
         assert.isTrue(tile === "Please provide correct QuadKey");
     });

--- a/@here/olp-sdk-dataservice-read/tslint.json
+++ b/@here/olp-sdk-dataservice-read/tslint.json
@@ -113,7 +113,7 @@
       "check-whitespace"
     ],
     "only-arrow-functions": [
-      true,
+      false,
       "allow-declarations",
       "allow-named-functions"
     ],

--- a/@here/olp-sdk-dataservice-write/test/unit/CancelBatchRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/CancelBatchRequest.test.ts
@@ -26,15 +26,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CancelBatchRequest", () => {
-    it("Should initialize", () => {
+describe("CancelBatchRequest", function() {
+    it("Should initialize", function() {
         const request = new CancelBatchRequest();
 
         assert.isDefined(request);
         expect(request).be.instanceOf(CancelBatchRequest);
     });
 
-    it("Should set and get parameters", () => {
+    it("Should set and get parameters", function() {
         const mockedPublicationId = "publication-id";
         const mockedBillingTag = "mocked-billing-tag";
 

--- a/@here/olp-sdk-dataservice-write/test/unit/CheckDataExistsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/CheckDataExistsRequest.test.ts
@@ -26,15 +26,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CheckDataExistsRequest", () => {
-    it("Should initialize", () => {
+describe("CheckDataExistsRequest", function() {
+    it("Should initialize", function() {
         const request = new CheckDataExistsRequest();
 
         assert.isDefined(request);
         expect(request).be.instanceOf(CheckDataExistsRequest);
     });
 
-    it("Should set and get parameters", () => {
+    it("Should set and get parameters", function() {
         const mockedLayer = "layer-0";
         const mockedBillingTag = "mocked-billing-tag";
         const mockedDataHandle = "datahandle123";

--- a/@here/olp-sdk-dataservice-write/test/unit/CompleteBatchRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/CompleteBatchRequest.test.ts
@@ -26,15 +26,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CompleteBatchRequest", () => {
-    it("Should initialize", () => {
+describe("CompleteBatchRequest", function() {
+    it("Should initialize", function() {
         const request = new CompleteBatchRequest();
 
         assert.isDefined(request);
         expect(request).be.instanceOf(CompleteBatchRequest);
     });
 
-    it("Should set and get parameters", () => {
+    it("Should set and get parameters", function() {
         const mockedPublicationId = "publication-id";
         const mockedBillingTag = "mocked-billing-tag";
 

--- a/@here/olp-sdk-dataservice-write/test/unit/GetBatchRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/GetBatchRequest.test.ts
@@ -26,15 +26,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("GetBatchRequest", () => {
-    it("Should initialize", () => {
+describe("GetBatchRequest", function() {
+    it("Should initialize", function() {
         const request = new GetBatchRequest();
 
         assert.isDefined(request);
         expect(request).be.instanceOf(GetBatchRequest);
     });
 
-    it("Should set and get parameters", () => {
+    it("Should set and get parameters", function() {
         const mockedPublicationId = "publication-id";
         const mockedBillingTag = "mocked-billing-tag";
 

--- a/@here/olp-sdk-dataservice-write/test/unit/PublishSinglePartitionRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/PublishSinglePartitionRequest.test.ts
@@ -26,15 +26,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("PublishSinglePartitionRequest", () => {
-    it("Should initialize", () => {
+describe("PublishSinglePartitionRequest", function() {
+    it("Should initialize", function() {
         const request = new PublishSinglePartitionRequest();
 
         assert.isDefined(request);
         expect(request).be.instanceOf(PublishSinglePartitionRequest);
     });
 
-    it("Should set and get parameters", () => {
+    it("Should set and get parameters", function() {
         const mockedPublicationId = "publication-id";
         const mockedLayerId = "mocked-layer-id";
         const mockedData = Buffer.from("mocked-data", "utf-8");

--- a/@here/olp-sdk-dataservice-write/test/unit/StartBatchRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/StartBatchRequest.test.ts
@@ -26,15 +26,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("StartBatchRequest", () => {
-    it("Should initialize", () => {
+describe("StartBatchRequest", function() {
+    it("Should initialize", function() {
         const request = new StartBatchRequest();
 
         assert.isDefined(request);
         expect(request).be.instanceOf(StartBatchRequest);
     });
 
-    it("Should set and get parameters", () => {
+    it("Should set and get parameters", function() {
         const mockedLayers = ["layer-0", "layer-1", "layer-2"];
         const mockedBillingTag = "mocked-billing-tag";
         const mockedVersionDependencies = [

--- a/@here/olp-sdk-dataservice-write/test/unit/UploadPartitionsRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/UploadPartitionsRequest.test.ts
@@ -26,15 +26,15 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("UploadPartitionsRequest", () => {
-    it("Should initialize", () => {
+describe("UploadPartitionsRequest", function() {
+    it("Should initialize", function() {
         const request = new UploadPartitionsRequest();
 
         assert.isDefined(request);
         expect(request).be.instanceOf(UploadPartitionsRequest);
     });
 
-    it("Should set and get parameters", () => {
+    it("Should set and get parameters", function() {
         const mockedPublicationId = "publication-id";
         const mockedLayerId = "mocked-layer-id";
         const mockedMetadata = {

--- a/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
@@ -233,7 +233,7 @@ describe("VersionedLayerClient write", function() {
     });
 
     it("Should cancel the publication", async function() {
-        cancelPublicationStub.callsFake(() => {
+        cancelPublicationStub.callsFake(function() {
             return Promise.resolve({
                 status: 204
             });
@@ -251,7 +251,7 @@ describe("VersionedLayerClient write", function() {
     });
 
     it("Should rejects with error a cancel the publication operation", async function() {
-        cancelPublicationStub.callsFake(() => {
+        cancelPublicationStub.callsFake(function() {
             return Promise.reject({
                 message: "Internal Server Error",
                 status: 500
@@ -289,7 +289,7 @@ describe("VersionedLayerClient write", function() {
     });
 
     it("Should submit the publication", async function() {
-        submitPublicationStub.callsFake(() => {
+        submitPublicationStub.callsFake(function() {
             return Promise.resolve({
                 status: 204
             });
@@ -307,7 +307,7 @@ describe("VersionedLayerClient write", function() {
     });
 
     it("Should rejects with error a submit the publication operation", async function() {
-        submitPublicationStub.callsFake(() => {
+        submitPublicationStub.callsFake(function() {
             return Promise.reject({
                 message: "Internal Server Error",
                 status: 500
@@ -345,7 +345,7 @@ describe("VersionedLayerClient write", function() {
     });
 
     it("Should return the publication details", async function() {
-        getPublicationStub.callsFake(() => {
+        getPublicationStub.callsFake(function() {
             return Promise.resolve({
                 catalogId: "sdk-writing-test",
                 catalogVersion: 37,
@@ -380,7 +380,7 @@ describe("VersionedLayerClient write", function() {
     });
 
     it("Should rejects with error when getting the publication details", async function() {
-        getPublicationStub.callsFake(() => {
+        getPublicationStub.callsFake(function() {
             return Promise.reject({
                 message: "Internal Server Error",
                 status: 500

--- a/@here/olp-sdk-dataservice-write/tslint.json
+++ b/@here/olp-sdk-dataservice-write/tslint.json
@@ -113,7 +113,7 @@
       "check-whitespace"
     ],
     "only-arrow-functions": [
-      true,
+      false,
       "allow-declarations",
       "allow-named-functions"
     ],

--- a/@here/olp-sdk-fetch/test/Fetch.test.ts
+++ b/@here/olp-sdk-fetch/test/Fetch.test.ts
@@ -21,8 +21,6 @@ import { assert } from "chai";
 import * as path from "path";
 import "../index";
 
-// tslint:disable:only-arrow-functions
-
 const isNode = typeof window === "undefined";
 const describeOnlyNode = isNode ? describe : xdescribe;
 
@@ -46,7 +44,10 @@ describe("@here/harp-fetch", function() {
 
     describeOnlyNode("global.fetch file support (node.js)", function() {
         function getRelativeResourcePath(filePath: string) {
-            return path.relative(process.cwd(), path.resolve(__dirname, filePath));
+            return path.relative(
+                process.cwd(),
+                path.resolve(__dirname, filePath)
+            );
         }
 
         it("loads binaries", async function() {

--- a/@here/olp-sdk-fetch/tslint.json
+++ b/@here/olp-sdk-fetch/tslint.json
@@ -113,7 +113,7 @@
       "check-whitespace"
     ],
     "only-arrow-functions": [
-      true,
+      false,
       "allow-declarations",
       "allow-named-functions"
     ],

--- a/tests/functional/StreamLayerReadData.test.ts
+++ b/tests/functional/StreamLayerReadData.test.ts
@@ -47,13 +47,13 @@ import {
   SeekRequest
 } from "@here/olp-sdk-dataservice-read";
 
-describe("Stream Layer Client Read Data", async () => {
+describe("Stream Layer Client Read Data", async function() {
   const olpClientSettings = new OlpClientSettings({
     environment: `http://${SERVER_HOST}:${SERVER_PORT}`,
     getToken: () => Promise.resolve("mocked-token-string")
   });
 
-  before(async () => {
+  before(async function() {
     await mockserver.start_mockserver({
       serverPort: SERVER_PORT,
       trace: true
@@ -61,7 +61,7 @@ describe("Stream Layer Client Read Data", async () => {
     console.log("Started Mocked Server\n");
   });
 
-  after(async () => {
+  after(async function() {
     await mockserver.stop_mockserver({
       serverPort: SERVER_PORT
     });
@@ -69,7 +69,7 @@ describe("Stream Layer Client Read Data", async () => {
     console.log("Stoped Mocked Server\n");
   });
 
-  it("Should Subscribe, Read messages, Read Blob and Unsubscribe from the layer", async () => {
+  it("Should Subscribe, Read messages, Read Blob and Unsubscribe from the layer", async function() {
     const client = new StreamLayerClient({
       catalogHrn: HRN.fromString(MOCKED_CATALOG_WITH_STREAM_LAYER_HRN),
       layerId: MOCKED_STREAM_LAYER_ID,
@@ -225,7 +225,7 @@ describe("Stream Layer Client Read Data", async () => {
         }
       ])
       .then(
-        () => {
+        function() {
           console.log(
             "Created expectations.\nMock server training finished.\n"
           );

--- a/tests/integration/api-breaks/ArtifactApi.test.ts
+++ b/tests/integration/api-breaks/ArtifactApi.test.ts
@@ -48,8 +48,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("ArtifactApi", () => {
-  it("Artifact with all required params", () => {
+describe("ArtifactApi", function() {
+  it("Artifact with all required params", function() {
     const params: Artifact = {
       artifactId: "test",
       created: {} as Date,
@@ -62,13 +62,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("ArtifactFile with all required params", () => {
+  it("ArtifactFile with all required params", function() {
     const params: ArtifactFile = {};
 
     assert.isDefined(params);
   });
 
-  it("ArtifactFile with all required and optional params", () => {
+  it("ArtifactFile with all required and optional params", function() {
     const params: ArtifactFile = {
       name: "test"
     };
@@ -76,13 +76,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("DeleteArtifactResponse with all required params", () => {
+  it("DeleteArtifactResponse with all required params", function() {
     const params: DeleteArtifactResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("DeleteArtifactResponse with all required and optional params", () => {
+  it("DeleteArtifactResponse with all required and optional params", function() {
     const params: DeleteArtifactResponse = {
       artifact: {
         artifactId: "test",
@@ -98,13 +98,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("DeleteFileResponse with all required params", () => {
+  it("DeleteFileResponse with all required params", function() {
     const params: DeleteFileResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("DeleteFileResponse with all required and optional params", () => {
+  it("DeleteFileResponse with all required and optional params", function() {
     const params: DeleteFileResponse = {
       artifact: {
         artifactId: "test",
@@ -120,13 +120,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("DeleteSchemaResponse with all required params", () => {
+  it("DeleteSchemaResponse with all required params", function() {
     const params: DeleteSchemaResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("DeleteSchemaResponse with all required and optional params", () => {
+  it("DeleteSchemaResponse with all required and optional params", function() {
     const params: DeleteSchemaResponse = {
       artifacts: [
         {
@@ -153,13 +153,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("DeleteSchemaResponse with all required params", () => {
+  it("DeleteSchemaResponse with all required params", function() {
     const params: DeleteSchemaResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("DeleteSchemaResponse with all required and optional params", () => {
+  it("DeleteSchemaResponse with all required and optional params", function() {
     const params: DeleteSchemaResponse = {
       artifacts: [
         {
@@ -186,7 +186,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("Schema with all required params", () => {
+  it("Schema with all required params", function() {
     const params: Schema = {
       artifactId: "test",
       created: {} as Date,
@@ -200,7 +200,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("Schema with all required and optional params", () => {
+  it("Schema with all required and optional params", function() {
     const params: Schema = {
       artifactId: "test",
       created: {} as Date,
@@ -215,13 +215,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("GetArtifactResponse with all required params", () => {
+  it("GetArtifactResponse with all required params", function() {
     const params: GetArtifactResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("GetArtifactResponse with all required and optional params", () => {
+  it("GetArtifactResponse with all required and optional params", function() {
     const params: GetArtifactResponse = {
       artifact: {
         artifactId: "test",
@@ -241,13 +241,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("GetSchemaResponse with all required params", () => {
+  it("GetSchemaResponse with all required params", function() {
     const params: GetSchemaResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("GetSchemaResponse with all required and optional params", () => {
+  it("GetSchemaResponse with all required and optional params", function() {
     const params: GetSchemaResponse = {
       artifacts: [
         {
@@ -280,13 +280,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("ListSchemasResponse with all required params", () => {
+  it("ListSchemasResponse with all required params", function() {
     const params: ListSchemasResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("ListSchemasResponse with all required and optional params", () => {
+  it("ListSchemasResponse with all required and optional params", function() {
     const params: ListSchemasResponse = {
       items: [
         {
@@ -309,7 +309,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("PagedQuery with all required params", () => {
+  it("PagedQuery with all required params", function() {
     const params: PagedQuery = {
       order: "ASC",
       sort: "test"
@@ -318,7 +318,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("PagedQuery with all required and optional params", () => {
+  it("PagedQuery with all required and optional params", function() {
     const params: PagedQuery = {
       from: "test",
       limit: 1,
@@ -329,7 +329,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("Principal with all required params", () => {
+  it("Principal with all required params", function() {
     const params: Principal = {
       type: "User",
       token: "test"
@@ -338,13 +338,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("RegisterArtifactRequest with all required params", () => {
+  it("RegisterArtifactRequest with all required params", function() {
     const params: RegisterArtifactRequest = {};
 
     assert.isDefined(params);
   });
 
-  it("RegisterArtifactRequest with all required and optional params", () => {
+  it("RegisterArtifactRequest with all required and optional params", function() {
     const params: RegisterArtifactRequest = {
       userId: "test"
     };
@@ -352,13 +352,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("RegisterArtifactResponse with all required params", () => {
+  it("RegisterArtifactResponse with all required params", function() {
     const params: RegisterArtifactResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("RegisterArtifactResponse with all required and optional params", () => {
+  it("RegisterArtifactResponse with all required and optional params", function() {
     const params: RegisterArtifactResponse = {
       artifactId: "test",
       created: true,
@@ -369,7 +369,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("SchemaValidationResults with all required params", () => {
+  it("SchemaValidationResults with all required params", function() {
     const params: SchemaValidationResults = {
       module: "test"
     };
@@ -377,7 +377,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("SchemaValidationResults with all required and optional params", () => {
+  it("SchemaValidationResults with all required and optional params", function() {
     const params: SchemaValidationResults = {
       backwardsCompatibility: true,
       fileExtension: true,
@@ -390,7 +390,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("UpdatePermissionRequest with all required params", () => {
+  it("UpdatePermissionRequest with all required params", function() {
     const params: UpdatePermissionRequest = {
       principal: {
         type: "User",
@@ -402,7 +402,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("UpdatePermissionRequest with all required and optional params", () => {
+  it("UpdatePermissionRequest with all required and optional params", function() {
     const params: UpdatePermissionRequest = {
       principal: {
         type: "User",
@@ -415,13 +415,13 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("UpdatePermissionResponse with all required params", () => {
+  it("UpdatePermissionResponse with all required params", function() {
     const params: UpdatePermissionResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("UpdatePermissionResponse with all required and optional params", () => {
+  it("UpdatePermissionResponse with all required and optional params", function() {
     const params: UpdatePermissionResponse = {
       principal: {
         type: "User",
@@ -434,7 +434,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("Variant with all required params", () => {
+  it("Variant with all required params", function() {
     const params: Variant = {
       id: "test",
       url: "test"
@@ -443,7 +443,7 @@ describe("ArtifactApi", () => {
     assert.isDefined(params);
   });
 
-  it("Test deleteArtifactUsingDELETE method with all required params", async () => {
+  it("Test deleteArtifactUsingDELETE method with all required params", async function() {
     const params = {
       artifactHrn: "mocked-artifactHrn"
     };
@@ -456,7 +456,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteFileUsingDELETE method with all required params", async () => {
+  it("Test deleteFileUsingDELETE method with all required params", async function() {
     const params = {
       artifactHrn: "mocked-artifactHrn",
       fileName: "mocked-fileName"
@@ -468,7 +468,7 @@ describe("ArtifactApi", () => {
     );
   });
 
-  it("Test getArtifactFileUsingGET method with all required params", async () => {
+  it("Test getArtifactFileUsingGET method with all required params", async function() {
     const params = {
       artifactHrn: "mocked-artifactHrn",
       fileName: "mocked-fileName"
@@ -482,7 +482,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getArtifactUsingGET method with all required params", async () => {
+  it("Test getArtifactUsingGET method with all required params", async function() {
     const params = {
       artifactHrn: "mocked-artifactHrn",
       fileName: "mocked-fileName"
@@ -496,7 +496,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test putArtifactFileUsingPUT method with all required params", async () => {
+  it("Test putArtifactFileUsingPUT method with all required params", async function() {
     const params = {
       artifactHrn: "mocked-artifactHrn",
       fileName: "mocked-fileName",
@@ -511,7 +511,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test registerArtifactUsingPUT method with all required params", async () => {
+  it("Test registerArtifactUsingPUT method with all required params", async function() {
     const params = {
       groupId: "mocked-groupId",
       artifactId: "mocked-artifactId"
@@ -525,7 +525,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test registerArtifactUsingPUT method with all required and optional params", async () => {
+  it("Test registerArtifactUsingPUT method with all required and optional params", async function() {
     const params = {
       groupId: "mocked-groupId",
       artifactId: "mocked-artifactId",
@@ -540,7 +540,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteSchemaUsingDELETE method with all required params", async () => {
+  it("Test deleteSchemaUsingDELETE method with all required params", async function() {
     const params = {
       schemaHrn: "mocked-schemaHrn"
     };
@@ -553,7 +553,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getDocumentUsingGET method with all required params", async () => {
+  it("Test getDocumentUsingGET method with all required params", async function() {
     const params = {
       schemaHrn: "mocked-schemaHrn",
       file: "mocked-file"
@@ -567,7 +567,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getSchemaUsingGET( method with all required params", async () => {
+  it("Test getSchemaUsingGET( method with all required params", async function() {
     const params = {
       schemaHrn: "mocked-schemaHrn"
     };
@@ -580,7 +580,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test listUsingGET method with all required params", async () => {
+  it("Test listUsingGET method with all required params", async function() {
     const params = {};
 
     const result = await ArtifactApi.listUsingGET(mockedRequestBuilder, params);
@@ -588,7 +588,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test listUsingGET method with all required and optional params", async () => {
+  it("Test listUsingGET method with all required and optional params", async function() {
     const params = {
       sort: "mocked-sort",
       order: "mocked-order" as any,
@@ -601,7 +601,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test updateSchemaPermissionUsingPOST method with all required params", async () => {
+  it("Test updateSchemaPermissionUsingPOST method with all required params", async function() {
     const params = {
       schemaHrn: "mocked-schemaHrn"
     };
@@ -614,7 +614,7 @@ describe("ArtifactApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test updateSchemaPermissionUsingPOST method with all required and optional params", async () => {
+  it("Test updateSchemaPermissionUsingPOST method with all required and optional params", async function() {
     const params = {
       schemaHrn: "mocked-schemaHrn",
       updatePermissionRequest: "mocked-updatePermissionRequest" as any

--- a/tests/integration/api-breaks/ArtifactClient.test.ts
+++ b/tests/integration/api-breaks/ArtifactClient.test.ts
@@ -32,7 +32,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("ArtifactClient", () => {
+describe("ArtifactClient", function() {
   class ArtifactClientTest extends ArtifactClient {
     constructor(settings: OlpClientSettings) {
       super(settings);
@@ -63,7 +63,7 @@ describe("ArtifactClient", () => {
     getToken: () => Promise.resolve("mocked-token")
   });
 
-  it("Shoud be initialized with arguments", async () => {
+  it("Shoud be initialized with arguments", async function() {
     const artifactClient = new ArtifactClient(settings);
     assert.isDefined(artifactClient);
 
@@ -72,7 +72,7 @@ describe("ArtifactClient", () => {
     assert.isDefined(artifactClient.getSchema);
   });
 
-  it("Test getSchemaDetails method with schemaDetailsRequest", async () => {
+  it("Test getSchemaDetails method with schemaDetailsRequest", async function() {
     const artifactClient = new ArtifactClientTest(settings);
 
     const response = await artifactClient.getSchemaDetails(
@@ -81,7 +81,7 @@ describe("ArtifactClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getSchema method with schemaRequest", async () => {
+  it("Test getSchema method with schemaRequest", async function() {
     const artifactClient = new ArtifactClientTest(settings);
 
     const response = await artifactClient.getSchema(

--- a/tests/integration/api-breaks/BlobApi.test.ts
+++ b/tests/integration/api-breaks/BlobApi.test.ts
@@ -40,14 +40,14 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("BlobApi", () => {
-  it("BlobInitResponse  with all required params", () => {
+describe("BlobApi", function() {
+  it("BlobInitResponse  with all required params", function() {
     const params: BlobInitResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("BlobInitResponse with all required and optional params", () => {
+  it("BlobInitResponse with all required and optional params", function() {
     const params: BlobInitResponse = {
       links: {
         complete: {
@@ -75,13 +75,13 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseCancelLink  with all required params", () => {
+  it("BlobInitResponseCancelLink  with all required params", function() {
     const params: BlobInitResponseCancelLink = {};
 
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseCancelLink with all required and optional params", () => {
+  it("BlobInitResponseCancelLink with all required and optional params", function() {
     const params: BlobInitResponseCancelLink = {
       href: "test",
       method: "test"
@@ -90,13 +90,13 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseCompleteLink  with all required params", () => {
+  it("BlobInitResponseCompleteLink  with all required params", function() {
     const params: BlobInitResponseCompleteLink = {};
 
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseCompleteLink with all required and optional params", () => {
+  it("BlobInitResponseCompleteLink with all required and optional params", function() {
     const params: BlobInitResponseCompleteLink = {
       href: "test",
       method: "test"
@@ -105,13 +105,13 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseLinks  with all required params", () => {
+  it("BlobInitResponseLinks  with all required params", function() {
     const params: BlobInitResponseLinks = {};
 
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseLinks with all required and optional params", () => {
+  it("BlobInitResponseLinks with all required and optional params", function() {
     const params: BlobInitResponseLinks = {
       complete: {
         href: "test",
@@ -137,13 +137,13 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseStatusLink  with all required params", () => {
+  it("BlobInitResponseStatusLink  with all required params", function() {
     const params: BlobInitResponseStatusLink = {};
 
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseStatusLink with all required and optional params", () => {
+  it("BlobInitResponseStatusLink with all required and optional params", function() {
     const params: BlobInitResponseStatusLink = {
       href: "test",
       method: "test"
@@ -152,13 +152,13 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseUploadPartLink  with all required params", () => {
+  it("BlobInitResponseUploadPartLink  with all required params", function() {
     const params: BlobInitResponseUploadPartLink = {};
 
     assert.isDefined(params);
   });
 
-  it("BlobInitResponseUploadPartLink with all required and optional params", () => {
+  it("BlobInitResponseUploadPartLink with all required and optional params", function() {
     const params: BlobInitResponseUploadPartLink = {
       href: "test",
       method: "test"
@@ -167,13 +167,13 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("MultipartCompletePart  with all required params", () => {
+  it("MultipartCompletePart  with all required params", function() {
     const params: MultipartCompletePart = {};
 
     assert.isDefined(params);
   });
 
-  it("MultipartCompletePart with all required and optional params", () => {
+  it("MultipartCompletePart with all required and optional params", function() {
     const params: MultipartCompletePart = {
       etag: "test",
       number: 1
@@ -182,13 +182,13 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("MultipartCompleteRequest  with all required params", () => {
+  it("MultipartCompleteRequest  with all required params", function() {
     const params: MultipartCompleteRequest = {};
 
     assert.isDefined(params);
   });
 
-  it("MultipartCompleteRequest with all required and optional params", () => {
+  it("MultipartCompleteRequest with all required and optional params", function() {
     const params: MultipartCompleteRequest = {
       parts: [
         {
@@ -201,7 +201,7 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("MultipartUploadMetadata  with all required params", () => {
+  it("MultipartUploadMetadata  with all required params", function() {
     const params: MultipartUploadMetadata = {
       contentType: "test"
     };
@@ -209,7 +209,7 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("MultipartUploadMetadata with all required and optional params", () => {
+  it("MultipartUploadMetadata with all required and optional params", function() {
     const params: MultipartUploadMetadata = {
       contentEncoding: "gzip",
       contentType: "test"
@@ -218,13 +218,13 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("MultipartUploadStatus  with all required params", () => {
+  it("MultipartUploadStatus  with all required params", function() {
     const params: MultipartUploadStatus = {};
 
     assert.isDefined(params);
   });
 
-  it("MultipartUploadStatus with all required and optional params", () => {
+  it("MultipartUploadStatus with all required and optional params", function() {
     const params: MultipartUploadStatus = {
       status: "failed"
     };
@@ -232,7 +232,7 @@ describe("BlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("Test cancelMultipartUpload method with all required params", async () => {
+  it("Test cancelMultipartUpload method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -247,7 +247,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test cancelMultipartUpload method with all required and optional params", async () => {
+  it("Test cancelMultipartUpload method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -263,7 +263,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test checkBlobExists method with all required params", async () => {
+  it("Test checkBlobExists method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle"
@@ -274,7 +274,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test checkBlobExists method with all required and optional params", async () => {
+  it("Test checkBlobExists method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -286,7 +286,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test completeMultipartUpload method with all required params", async () => {
+  it("Test completeMultipartUpload method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -302,7 +302,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test completeMultipartUpload method with all required and optional params", async () => {
+  it("Test completeMultipartUpload method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -321,7 +321,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteBlob method with all required params", async () => {
+  it("Test deleteBlob method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle"
@@ -330,7 +330,7 @@ describe("BlobApi", () => {
     const result = await BlobApi.deleteBlob(mockedRequestBuilder, params);
   });
 
-  it("Test deleteBlob method with all required and optional params", async () => {
+  it("Test deleteBlob method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -342,7 +342,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getBlob method with all required params", async () => {
+  it("Test getBlob method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -354,7 +354,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getBlob method with all required and optional params", async () => {
+  it("Test getBlob method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -367,7 +367,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getMultipartUploadStatus method with all required params", async () => {
+  it("Test getMultipartUploadStatus method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -382,7 +382,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getMultipartUploadStatus method with all required and optional params", async () => {
+  it("Test getMultipartUploadStatus method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -398,7 +398,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test putBlob method with all required params", async () => {
+  it("Test putBlob method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -411,7 +411,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test putBlob method with all required and optional params", async () => {
+  it("Test putBlob method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -425,7 +425,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test startMultipartUpload method with all required params", async () => {
+  it("Test startMultipartUpload method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -440,7 +440,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test startMultipartUpload method with all required and optional params", async () => {
+  it("Test startMultipartUpload method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -456,7 +456,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test uploadPart method with all required params", async () => {
+  it("Test uploadPart method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",
@@ -472,7 +472,7 @@ describe("BlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test uploadPart method with all required and optional params", async () => {
+  it("Test uploadPart method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       dataHandle: "mocked-datahandle",

--- a/tests/integration/api-breaks/CatalogClient.test.ts
+++ b/tests/integration/api-breaks/CatalogClient.test.ts
@@ -33,7 +33,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CatalogClient", () => {
+describe("CatalogClient", function() {
   class CatalogClientTest extends CatalogClient {
     constructor(catalogHrn: HRN, settings: OlpClientSettings) {
       super(catalogHrn, settings);
@@ -94,7 +94,7 @@ describe("CatalogClient", () => {
     getToken: () => Promise.resolve("mocked-token")
   });
 
-  it("Shoud be initialized with arguments", async () => {
+  it("Shoud be initialized with arguments", async function() {
     const catalogClient = new CatalogClient(mockedHRN, settings);
     assert.isDefined(catalogClient);
 
@@ -105,7 +105,7 @@ describe("CatalogClient", () => {
     assert.isDefined(catalogClient.getLayerVersions);
   });
 
-  it("Test getCatalog method with request", async () => {
+  it("Test getCatalog method with request", async function() {
     const catalogClient = new CatalogClientTest(mockedHRN, settings);
 
     const response = await catalogClient.getCatalog(
@@ -114,7 +114,7 @@ describe("CatalogClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getCatalog method with catalogRequest and abortSignal", async () => {
+  it("Test getCatalog method with catalogRequest and abortSignal", async function() {
     const catalogClient = new CatalogClientTest(mockedHRN, settings);
     const abortSignal: any = "test";
 
@@ -125,7 +125,7 @@ describe("CatalogClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getEarliestVersion method with catalogVersionRequest", async () => {
+  it("Test getEarliestVersion method with catalogVersionRequest", async function() {
     const catalogClient = new CatalogClientTest(mockedHRN, settings);
 
     const response = await catalogClient.getEarliestVersion(
@@ -134,7 +134,7 @@ describe("CatalogClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getEarliestVersion method with catalogVersionRequest and abortSignal", async () => {
+  it("Test getEarliestVersion method with catalogVersionRequest and abortSignal", async function() {
     const catalogClient = new CatalogClientTest(mockedHRN, settings);
     const abortSignal: any = "test";
 
@@ -145,7 +145,7 @@ describe("CatalogClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getLatestVersion method with catalogVersionRequest", async () => {
+  it("Test getLatestVersion method with catalogVersionRequest", async function() {
     const catalogClient = new CatalogClientTest(mockedHRN, settings);
 
     const response = await catalogClient.getLatestVersion(
@@ -154,7 +154,7 @@ describe("CatalogClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getLatestVersion method with catalogVersionRequest and abortSignal", async () => {
+  it("Test getLatestVersion method with catalogVersionRequest and abortSignal", async function() {
     const catalogClient = new CatalogClientTest(mockedHRN, settings);
     const abortSignal: any = "test";
 
@@ -165,7 +165,7 @@ describe("CatalogClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getLayerVersions method with layerVersionsRequest", async () => {
+  it("Test getLayerVersions method with layerVersionsRequest", async function() {
     const catalogClient = new CatalogClientTest(mockedHRN, settings);
 
     const response = await catalogClient.getLayerVersions(
@@ -174,7 +174,7 @@ describe("CatalogClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getLayerVersions method with layerVersionsRequest and abortSignal", async () => {
+  it("Test getLayerVersions method with layerVersionsRequest and abortSignal", async function() {
     const catalogClient = new CatalogClientTest(mockedHRN, settings);
     const abortSignal: any = "test";
 

--- a/tests/integration/api-breaks/CatalogRequest.test.ts
+++ b/tests/integration/api-breaks/CatalogRequest.test.ts
@@ -26,7 +26,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CatalogRequest", () => {
+describe("CatalogRequest", function() {
   class CatalogRequestTest extends CatalogRequest {
     withBillingTag(tag: string): CatalogRequest {
       return this;
@@ -37,7 +37,7 @@ describe("CatalogRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const catalogRequest = new CatalogRequestTest();
     assert.isDefined(catalogRequest);
     expect(catalogRequest).to.be.instanceOf(CatalogRequest);
@@ -46,14 +46,14 @@ describe("CatalogRequest", () => {
     assert.isFunction(catalogRequest.getBillingTag);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const catalogRequest = new CatalogRequestTest();
 
     const response = catalogRequest.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const catalogRequest = new CatalogRequestTest();
     catalogRequest.withBillingTag("test-tag");
 

--- a/tests/integration/api-breaks/CatalogVersionRequest.test.ts
+++ b/tests/integration/api-breaks/CatalogVersionRequest.test.ts
@@ -26,7 +26,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CatalogVersionRequest", () => {
+describe("CatalogVersionRequest", function() {
   class CatalogVersionRequestTest extends CatalogVersionRequest {
     getStartVersion(): number {
       return 5;
@@ -53,7 +53,7 @@ describe("CatalogVersionRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const catalogRequest = new CatalogVersionRequestTest();
     assert.isDefined(catalogRequest);
     expect(catalogRequest).to.be.instanceOf(CatalogVersionRequest);
@@ -66,42 +66,42 @@ describe("CatalogVersionRequest", () => {
     assert.isFunction(catalogRequest.getBillingTag);
   });
 
-  it("Test withStartVersion method with version", async () => {
+  it("Test withStartVersion method with version", async function() {
     const request = new CatalogVersionRequestTest();
 
     const response = request.withStartVersion(1);
     assert.isDefined(response);
   });
 
-  it("Test getStartVersion method without params", async () => {
+  it("Test getStartVersion method without params", async function() {
     const request = new CatalogVersionRequestTest();
 
     const response = request.getStartVersion();
     assert.isDefined(response);
   });
 
-  it("Test withEndVersion method with version", async () => {
+  it("Test withEndVersion method with version", async function() {
     const request = new CatalogVersionRequestTest();
 
     const response = request.withEndVersion(25);
     assert.isDefined(response);
   });
 
-  it("Test getEndVersion method without params", async () => {
+  it("Test getEndVersion method without params", async function() {
     const request = new CatalogVersionRequestTest();
 
     const response = request.getEndVersion();
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const catalogRequest = new CatalogVersionRequestTest();
 
     const response = catalogRequest.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const catalogRequest = new CatalogVersionRequestTest();
     catalogRequest.withBillingTag("test-tag");
 

--- a/tests/integration/api-breaks/CatalogsRequest.test.ts
+++ b/tests/integration/api-breaks/CatalogsRequest.test.ts
@@ -26,7 +26,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CatalogsRequest", () => {
+describe("CatalogsRequest", function() {
   class CatalogsRequestTest extends CatalogsRequest {
     withSchema(schemaHrn: string): CatalogsRequest {
       return this;
@@ -44,7 +44,7 @@ describe("CatalogsRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const catalogsRequest = new CatalogsRequestTest();
     assert.isDefined(catalogsRequest);
     expect(catalogsRequest).to.be.instanceOf(CatalogsRequest);
@@ -53,28 +53,28 @@ describe("CatalogsRequest", () => {
     assert.isFunction(catalogsRequest.getBillingTag);
   });
 
-  it("Test withSchema method with schemaHrn", async () => {
+  it("Test withSchema method with schemaHrn", async function() {
     const catalogsRequest = new CatalogsRequestTest();
 
     const response = catalogsRequest.withSchema("test");
     assert.isDefined(response);
   });
 
-  it("Test getSchema method without params", async () => {
+  it("Test getSchema method without params", async function() {
     const catalogsRequest = new CatalogsRequestTest();
 
     const response = catalogsRequest.getSchema();
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const catalogsRequest = new CatalogsRequestTest();
 
     const response = catalogsRequest.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const catalogsRequest = new CatalogsRequestTest();
 
     const response = catalogsRequest.getBillingTag();

--- a/tests/integration/api-breaks/ConfigApi.test.ts
+++ b/tests/integration/api-breaks/ConfigApi.test.ts
@@ -41,8 +41,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("ConfigApi", () => {
-  it("ParentQuad with all required params", () => {
+describe("ConfigApi", function() {
+  it("ParentQuad with all required params", function() {
     const params: ParentQuad = {
       dataHandle: "test",
       partition: "test",
@@ -52,7 +52,7 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("ParentQuad with all required and optional params", () => {
+  it("ParentQuad with all required and optional params", function() {
     const params: ParentQuad = {
       additionalMetadata: "test",
       checksum: "test",
@@ -66,7 +66,7 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("SubQuad with all required params", () => {
+  it("SubQuad with all required params", function() {
     const params: SubQuad = {
       dataHandle: "test",
       subQuadKey: "test",
@@ -76,7 +76,7 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("SubQuad with all required and optional params", () => {
+  it("SubQuad with all required and optional params", function() {
     const params: SubQuad = {
       additionalMetadata: "test",
       checksum: "test",
@@ -90,7 +90,7 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("Index with all required params", () => {
+  it("Index with all required params", function() {
     const params: Index = {
       parentQuads: [
         {
@@ -112,7 +112,7 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("Layer with all required params", () => {
+  it("Layer with all required params", function() {
     const params: Layer = {
       hrn: "test",
       id: "test",
@@ -126,7 +126,7 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("Layer with all required and optional params", () => {
+  it("Layer with all required and optional params", function() {
     const params: Layer = {
       billingTags: ["test"],
       contentEncoding: "gzip",
@@ -164,7 +164,7 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("Catalog with all required params", () => {
+  it("Catalog with all required params", function() {
     const params: Catalog = {
       created: "test",
       description: "test",
@@ -222,7 +222,7 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("Catalog with all required and optional params", () => {
+  it("Catalog with all required and optional params", function() {
     const params: Catalog = {
       billingTags: ["text"],
       coverage: {
@@ -295,12 +295,12 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("CatalogFailureStatus with all required params", () => {
+  it("CatalogFailureStatus with all required params", function() {
     const params: CatalogFailureStatus = {};
     assert.isDefined(params);
   });
 
-  it("CatalogFailureStatus with all required and optional params", () => {
+  it("CatalogFailureStatus with all required and optional params", function() {
     const params: CatalogFailureStatus = {
       reason: "test",
       status: "test"
@@ -308,22 +308,22 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("CatalogPendingStatus with all required params", () => {
+  it("CatalogPendingStatus with all required params", function() {
     const params: CatalogPendingStatus = {};
     assert.isDefined(params);
   });
-  it("CatalogPendingStatus with all required and optional params", () => {
+  it("CatalogPendingStatus with all required and optional params", function() {
     const params: CatalogPendingStatus = {
       status: "test"
     };
     assert.isDefined(params);
   });
 
-  it("CatalogSummary with all required params", () => {
+  it("CatalogSummary with all required params", function() {
     const params: CatalogSummary = {};
     assert.isDefined(params);
   });
-  it("CatalogSummary with all required and optional params", () => {
+  it("CatalogSummary with all required and optional params", function() {
     const params: CatalogSummary = {
       href: "test",
       hrn: "test",
@@ -333,12 +333,12 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("CatalogsList with all required params", () => {
+  it("CatalogsList with all required params", function() {
     const params: CatalogsList = {};
     assert.isDefined(params);
   });
 
-  it("CatalogsList with all required and optional params", () => {
+  it("CatalogsList with all required and optional params", function() {
     const params: CatalogsList = {
       items: [
         {
@@ -352,12 +352,12 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("CatalogsListResult with all required params", () => {
+  it("CatalogsListResult with all required params", function() {
     const params: CatalogsListResult = {};
     assert.isDefined(params);
   });
 
-  it("CatalogsListResult with all required and optional params", () => {
+  it("CatalogsListResult with all required and optional params", function() {
     const params: CatalogsListResult = {
       results: {
         items: [
@@ -373,13 +373,13 @@ describe("ConfigApi", () => {
     assert.isDefined(params);
   });
 
-  it("StatusLink with all required params", () => {
+  it("StatusLink with all required params", function() {
     const params: StatusLink = {};
 
     assert.isDefined(params);
   });
 
-  it("StatusLink with all required and optional params", () => {
+  it("StatusLink with all required and optional params", function() {
     const params: StatusLink = {
       href: "test",
       title: "test",
@@ -391,7 +391,7 @@ describe("ConfigApi", () => {
 
   ////////////////
 
-  it("Test catalogExists method with all required params", async () => {
+  it("Test catalogExists method with all required params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn"
     };
@@ -401,7 +401,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test catalogExists method with all required and optional params", async () => {
+  it("Test catalogExists method with all required and optional params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn",
       billingTag: "mocked-billingTag"
@@ -412,7 +412,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test createCatalog method with all required params", async () => {
+  it("Test createCatalog method with all required params", async function() {
     const params = {
       body: "mocked-body" as any
     };
@@ -422,7 +422,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test createCatalog method with all required and optional params", async () => {
+  it("Test createCatalog method with all required and optional params", async function() {
     const params = {
       body: "mocked-body" as any,
       billingTag: "mocked-billingTag"
@@ -433,7 +433,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteCatalog method with all required params", async () => {
+  it("Test deleteCatalog method with all required params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn"
     };
@@ -443,7 +443,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteCatalog method with all required and optional params", async () => {
+  it("Test deleteCatalog method with all required and optional params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn",
       billingTag: "mocked-billingTag"
@@ -454,7 +454,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteLayer method with all required params", async () => {
+  it("Test deleteLayer method with all required params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn",
       layerId: "mocked-layerId"
@@ -465,7 +465,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getCatalog method with all required params", async () => {
+  it("Test getCatalog method with all required params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn",
       billingTag: "mocked-billingTag"
@@ -476,7 +476,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getCatalogStatus method with all required params", async () => {
+  it("Test getCatalogStatus method with all required params", async function() {
     const params = {
       token: "mocked-token",
       billingTag: "mocked-billingTag"
@@ -490,7 +490,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getCatalogs method with all required params", async () => {
+  it("Test getCatalogs method with all required params", async function() {
     const params = {};
 
     const result = await ConfigApi.getCatalogs(mockedRequestBuilder, params);
@@ -498,7 +498,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getCatalogs method with all required and optional params", async () => {
+  it("Test getCatalogs method with all required and optional params", async function() {
     const params = {
       billingTag: "mocked-billingTag" as any,
       verbose: "mocked-verbose" as any,
@@ -521,7 +521,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test patchCatalog method with all required params", async () => {
+  it("Test patchCatalog method with all required params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn",
       body: "mocked-body" as any
@@ -532,7 +532,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test patchLayer method with all required params", async () => {
+  it("Test patchLayer method with all required params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn",
       layerId: "mocked-layerId",
@@ -544,7 +544,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test updateCatalog method with all required params", async () => {
+  it("Test updateCatalog method with all required params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn",
       body: "mocked-body" as any
@@ -555,7 +555,7 @@ describe("ConfigApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test updateCatalog method with all required and optional params", async () => {
+  it("Test updateCatalog method with all required and optional params", async function() {
     const params = {
       catalogHrn: "mocked-catalogHrn",
       body: "mocked-body" as any,

--- a/tests/integration/api-breaks/ConfigClient.test.ts
+++ b/tests/integration/api-breaks/ConfigClient.test.ts
@@ -32,7 +32,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("ConfigClient", () => {
+describe("ConfigClient", function() {
   class ConfigClientTest extends ConfigClient {
     constructor(settings: OlpClientSettings) {
       super(settings);
@@ -52,7 +52,7 @@ describe("ConfigClient", () => {
     getToken: () => Promise.resolve("mocked-token")
   });
 
-  it("Shoud be initialized with arguments", async () => {
+  it("Shoud be initialized with arguments", async function() {
     const configClient = new ConfigClient(settings);
     assert.isDefined(configClient);
 
@@ -60,14 +60,14 @@ describe("ConfigClient", () => {
     assert.isDefined(configClient.getCatalogs);
   });
 
-  it("Test getCatalogs method without params", async () => {
+  it("Test getCatalogs method without params", async function() {
     const configClient = new ConfigClientTest(settings);
 
     const response = await configClient.getCatalogs();
     assert.isDefined(response);
   });
 
-  it("Test getCatalog method with catalogsRequest", async () => {
+  it("Test getCatalog method with catalogsRequest", async function() {
     const configClient = new ConfigClientTest(settings);
 
     const response = await configClient.getCatalogs(

--- a/tests/integration/api-breaks/CoverageApi.test.ts
+++ b/tests/integration/api-breaks/CoverageApi.test.ts
@@ -35,14 +35,14 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CoverageApi", () => {
-  it("BoundingBox with all required params", () => {
+describe("CoverageApi", function() {
+  it("BoundingBox with all required params", function() {
     const params: BoundingBox = {};
 
     assert.isDefined(params);
   });
 
-  it("BoundingBox with all optional params", () => {
+  it("BoundingBox with all optional params", function() {
     const params: BoundingBox = {
       east: "test",
       north: "test",
@@ -53,13 +53,13 @@ describe("CoverageApi", () => {
     assert.isDefined(params);
   });
 
-  it("CatalogAdminAreas with all required params", () => {
+  it("CatalogAdminAreas with all required params", function() {
     const params: CatalogAdminAreas = {};
 
     assert.isDefined(params);
   });
 
-  it("CatalogAdminAreas with all optional params", () => {
+  it("CatalogAdminAreas with all optional params", function() {
     const params: CatalogAdminAreas = {
       cities: ["test"],
       counties: ["test"],
@@ -70,7 +70,7 @@ describe("CoverageApi", () => {
     assert.isDefined(params);
   });
 
-  it("LayerBoundingBox  with all required params", () => {
+  it("LayerBoundingBox  with all required params", function() {
     const params: LayerBoundingBox = {
       east: 1,
       south: 1,
@@ -81,7 +81,7 @@ describe("CoverageApi", () => {
     assert.isDefined(params);
   });
 
-  it("LayerLevelSummary with all required params", () => {
+  it("LayerLevelSummary with all required params", function() {
     const params: LayerLevelSummary = {
       boundingBox: {
         east: 1,
@@ -101,7 +101,7 @@ describe("CoverageApi", () => {
     assert.isDefined(params);
   });
 
-  it("LayerSummary with all required params", () => {
+  it("LayerSummary with all required params", function() {
     const params: LayerSummary = {
       catalogHRN: "test-hrn",
       layer: "test",
@@ -127,7 +127,7 @@ describe("CoverageApi", () => {
     assert.isDefined(params);
   });
 
-  it("Test getDataCoverageAdminAreas method with all required params", async () => {
+  it("Test getDataCoverageAdminAreas method with all required params", async function() {
     const params = {
       layerId: "mocked-layerId",
       datalevel: "mocked-datalevel"
@@ -141,7 +141,7 @@ describe("CoverageApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getDataCoverageSizeMap method with all required params", async () => {
+  it("Test getDataCoverageSizeMap method with all required params", async function() {
     const params = {
       layerId: "mocked-layerId"
     };
@@ -154,7 +154,7 @@ describe("CoverageApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getDataCoverageSizeMap method with all required and optional params", async () => {
+  it("Test getDataCoverageSizeMap method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-layerId",
       datalevel: 12
@@ -168,7 +168,7 @@ describe("CoverageApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getDataCoverageSummary method with all required params", async () => {
+  it("Test getDataCoverageSummary method with all required params", async function() {
     const params = {
       layerId: "mocked-layerId"
     };
@@ -181,7 +181,7 @@ describe("CoverageApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getDataCoverageTile method with all required params", async () => {
+  it("Test getDataCoverageTile method with all required params", async function() {
     const params = {
       layerId: "mocked-layerId"
     };
@@ -194,7 +194,7 @@ describe("CoverageApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getDataCoverageTile method with all required and optional params", async () => {
+  it("Test getDataCoverageTile method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-layerId",
       datalevel: 12
@@ -208,7 +208,7 @@ describe("CoverageApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getDataCoverageTimeMap method with all required params", async () => {
+  it("Test getDataCoverageTimeMap method with all required params", async function() {
     const params = {
       layerId: "mocked-layerId",
       catalogHRN: "mocked-catalogHRN"
@@ -222,7 +222,7 @@ describe("CoverageApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getDataCoverageTimeMap method with all required and optional params", async () => {
+  it("Test getDataCoverageTimeMap method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-layerId",
       datalevel: 12,

--- a/tests/integration/api-breaks/DataRequest.test.ts
+++ b/tests/integration/api-breaks/DataRequest.test.ts
@@ -30,7 +30,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("DataRequest", () => {
+describe("DataRequest", function() {
   class DataRequestTest extends DataRequest {
     getDataHandle(): string | undefined {
       return "test";
@@ -77,7 +77,7 @@ describe("DataRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new DataRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(DataRequest);
@@ -94,21 +94,21 @@ describe("DataRequest", () => {
     assert.isFunction(request.getBillingTag);
   });
 
-  it("Test withVersion method with version", async () => {
+  it("Test withVersion method with version", async function() {
     const request = new DataRequestTest();
 
     const response = request.withVersion(3);
     assert.isDefined(response);
   });
 
-  it("Test getVersion method without params", async () => {
+  it("Test getVersion method without params", async function() {
     const request = new DataRequestTest();
 
     const response = request.getVersion();
     assert.isDefined(response);
   });
 
-  it("Test withQuadKey method with quadKey", async () => {
+  it("Test withQuadKey method with quadKey", async function() {
     const request = new DataRequestTest();
 
     const response = request.withQuadKey({
@@ -119,49 +119,49 @@ describe("DataRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getQuadKey method without params", async () => {
+  it("Test getQuadKey method without params", async function() {
     const request = new DataRequestTest();
 
     const response = request.getQuadKey();
     assert.isDefined(response);
   });
 
-  it("Test withPartitionId method with id", async () => {
+  it("Test withPartitionId method with id", async function() {
     const request = new DataRequestTest();
 
     const response = request.withPartitionId("test");
     assert.isDefined(response);
   });
 
-  it("Test getPartitionId method without params", async () => {
+  it("Test getPartitionId method without params", async function() {
     const request = new DataRequestTest();
 
     const response = request.getPartitionId();
     assert.isDefined(response);
   });
 
-  it("Test withDataHandle method with dataHandle", async () => {
+  it("Test withDataHandle method with dataHandle", async function() {
     const request = new DataRequestTest();
 
     const response = request.withDataHandle("test");
     assert.isDefined(response);
   });
 
-  it("Test getDataHandle method without params", async () => {
+  it("Test getDataHandle method without params", async function() {
     const request = new DataRequestTest();
 
     const response = request.getDataHandle();
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const request = new DataRequestTest();
 
     const response = request.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const request = new DataRequestTest();
 
     const response = request.getBillingTag();

--- a/tests/integration/api-breaks/HttpError.test.ts
+++ b/tests/integration/api-breaks/HttpError.test.ts
@@ -27,8 +27,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("HttpError", () => {
-  it("Shoud be initialized with arguments", async () => {
+describe("HttpError", function() {
+  it("Shoud be initialized with arguments", async function() {
     const testError = new HttpError(101, "Test Error");
     assert.isDefined(testError);
 
@@ -37,7 +37,7 @@ describe("HttpError", () => {
     assert.isDefined(testError.message);
   });
 
-  it("Test isHttpError method with HttpError", async () => {
+  it("Test isHttpError method with HttpError", async function() {
     const testError = new HttpError(101, "Test Error");
     const response = HttpError.isHttpError(testError);
     assert.isTrue(response);

--- a/tests/integration/api-breaks/HttpErrorAuth.test.ts
+++ b/tests/integration/api-breaks/HttpErrorAuth.test.ts
@@ -27,8 +27,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("Authentication HttpError", () => {
-  it("Shoud be initialized with arguments", async () => {
+describe("Authentication HttpError", function() {
+  it("Shoud be initialized with arguments", async function() {
     const testError = new HttpError(101, "Test Error");
     assert.isDefined(testError);
 
@@ -37,7 +37,7 @@ describe("Authentication HttpError", () => {
     assert.isDefined(testError.message);
   });
 
-  it("Test isHttpError method with HttpError", async () => {
+  it("Test isHttpError method with HttpError", async function() {
     const testError = new HttpError(101, "Test Error");
     const response = HttpError.isHttpError(testError);
     assert.isTrue(response);

--- a/tests/integration/api-breaks/IndexApi.test.ts
+++ b/tests/integration/api-breaks/IndexApi.test.ts
@@ -34,14 +34,14 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("IndexApi", () => {
-  it("DataResponse with all required params", () => {
+describe("IndexApi", function() {
+  it("DataResponse with all required params", function() {
     const params: DataResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("DataResponse with all required and optional params", () => {
+  it("DataResponse with all required and optional params", function() {
     const params: DataResponse = {
       data: [
         {
@@ -58,13 +58,13 @@ describe("IndexApi", () => {
     assert.isDefined(params);
   });
 
-  it("Index with all required params", () => {
+  it("Index with all required params", function() {
     const params: Index = {};
 
     assert.isDefined(params);
   });
 
-  it("Index with all required and optional params", () => {
+  it("Index with all required and optional params", function() {
     const params: Index = {
       checksum: "test",
       fields: "test",
@@ -76,7 +76,7 @@ describe("IndexApi", () => {
     assert.isDefined(params);
   });
 
-  it("MapStringObject with all required params", () => {
+  it("MapStringObject with all required params", function() {
     const params: MapStringObject = {
       mykey: "test"
     };
@@ -84,13 +84,13 @@ describe("IndexApi", () => {
     assert.isDefined(params);
   });
 
-  it("UpdateIndexRequest with all required params", () => {
+  it("UpdateIndexRequest with all required params", function() {
     const params: UpdateIndexRequest = {};
 
     assert.isDefined(params);
   });
 
-  it("UpdateIndexRequest with all required and optional params", () => {
+  it("UpdateIndexRequest with all required and optional params", function() {
     const params: UpdateIndexRequest = {
       additions: [
         {
@@ -107,7 +107,7 @@ describe("IndexApi", () => {
     assert.isDefined(params);
   });
 
-  it("Test insertIndexes method with all required params", async () => {
+  it("Test insertIndexes method with all required params", async function() {
     const params = {
       indexes: [
         {
@@ -126,7 +126,7 @@ describe("IndexApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test performQuery method with all required params", async () => {
+  it("Test performQuery method with all required params", async function() {
     const params = {
       layerID: "test",
       query: "test"
@@ -137,7 +137,7 @@ describe("IndexApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test performQuery method with all required and optional params", async () => {
+  it("Test performQuery method with all required and optional params", async function() {
     const params = {
       layerID: "test",
       query: "test",
@@ -149,7 +149,7 @@ describe("IndexApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test performUpdate method with all required params", async () => {
+  it("Test performUpdate method with all required params", async function() {
     const params = {
       layerID: "test",
       request: {

--- a/tests/integration/api-breaks/IndexLayerClient.test.ts
+++ b/tests/integration/api-breaks/IndexLayerClient.test.ts
@@ -33,8 +33,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("IndexLayerClientParams", () => {
-  it("IndexLayerClientParams with all required params", () => {
+describe("IndexLayerClientParams", function() {
+  it("IndexLayerClientParams with all required params", function() {
     const params: IndexLayerClientParams = {
       catalogHrn: HRN.fromString("hrn:here:data:::example-catalog"),
       layerId: "mocked-layer-id",
@@ -47,7 +47,7 @@ describe("IndexLayerClientParams", () => {
     assert.isDefined(params);
   });
 
-  it("IndexLayerClientParams with all required and optional params", () => {
+  it("IndexLayerClientParams with all required and optional params", function() {
     const params: IndexLayerClientParams = {
       catalogHrn: HRN.fromString("hrn:here:data:::example-catalog"),
       layerId: "mocked-layer-id",
@@ -61,7 +61,7 @@ describe("IndexLayerClientParams", () => {
   });
 });
 
-describe("IndexLayerClient", () => {
+describe("IndexLayerClient", function() {
   class IndexLayerClientTest extends IndexLayerClient {
     constructor(params: IndexLayerClientParams) {
       super(params);
@@ -82,11 +82,11 @@ describe("IndexLayerClient", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(function() {
     IndexLayerClientTest;
   });
 
-  it("Shoud be initialized with arguments", async () => {
+  it("Shoud be initialized with arguments", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -106,7 +106,7 @@ describe("IndexLayerClient", () => {
     assert.isDefined(layerClient.settings);
   });
 
-  it("Shoud be initialized with IndexLayerClientParams", async () => {
+  it("Shoud be initialized with IndexLayerClientParams", async function() {
     const layerClient = new IndexLayerClient({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -125,7 +125,7 @@ describe("IndexLayerClient", () => {
     assert.isDefined(layerClient.settings);
   });
 
-  it("getPartitions method with IndexQueryRequest", async () => {
+  it("getPartitions method with IndexQueryRequest", async function() {
     const layerClient = new IndexLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -139,7 +139,7 @@ describe("IndexLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getPartitions method with IndexQueryRequest and abort signal", async () => {
+  it("getPartitions method with IndexQueryRequest and abort signal", async function() {
     const layerClient = new IndexLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -158,7 +158,7 @@ describe("IndexLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getData method with model", async () => {
+  it("getData method with model", async function() {
     const layerClient = new IndexLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -182,7 +182,7 @@ describe("IndexLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getData method with empty model", async () => {
+  it("getData method with empty model", async function() {
     const layerClient = new IndexLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -198,7 +198,7 @@ describe("IndexLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getData method with model and abort signal", async () => {
+  it("getData method with model and abort signal", async function() {
     const layerClient = new IndexLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",

--- a/tests/integration/api-breaks/IndexQueryRequest.test.ts
+++ b/tests/integration/api-breaks/IndexQueryRequest.test.ts
@@ -26,7 +26,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("IndexQueryRequest", () => {
+describe("IndexQueryRequest", function() {
   class IndexQueryRequestTest extends IndexQueryRequest {
     withQueryString(query?: string): IndexQueryRequest {
       return this;
@@ -45,7 +45,7 @@ describe("IndexQueryRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new IndexQueryRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(IndexQueryRequest);
@@ -56,35 +56,35 @@ describe("IndexQueryRequest", () => {
     assert.isFunction(request.getQueryString);
   });
 
-  it("Test withHugeResponse method with isHuge", async () => {
+  it("Test withHugeResponse method with isHuge", async function() {
     const request = new IndexQueryRequestTest();
 
     const response = request.withHugeResponse(true);
     assert.isDefined(response);
   });
 
-  it("Test getHugeResponse method without params", async () => {
+  it("Test getHugeResponse method without params", async function() {
     const request = new IndexQueryRequestTest();
 
     const response = request.getHugeResponse();
     assert.isDefined(response);
   });
 
-  it("Test withQueryString method with query", async () => {
+  it("Test withQueryString method with query", async function() {
     const request = new IndexQueryRequestTest();
 
     const response = request.withQueryString("test");
     assert.isDefined(response);
   });
 
-  it("Test withQueryString method without params", async () => {
+  it("Test withQueryString method without params", async function() {
     const request = new IndexQueryRequestTest();
 
     const response = request.withQueryString();
     assert.isDefined(response);
   });
 
-  it("Test getQueryString method without params", async () => {
+  it("Test getQueryString method without params", async function() {
     const request = new IndexQueryRequestTest();
 
     const response = request.getQueryString();

--- a/tests/integration/api-breaks/KeyValueCache.test.ts
+++ b/tests/integration/api-breaks/KeyValueCache.test.ts
@@ -27,8 +27,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("KeyValueCache", () => {
-  it("Shoud be initialized withouth arguments", async () => {
+describe("KeyValueCache", function() {
+  it("Shoud be initialized withouth arguments", async function() {
     const testKeyValueCache = new KeyValueCache();
     assert.isDefined(testKeyValueCache);
 
@@ -38,14 +38,14 @@ describe("KeyValueCache", () => {
     assert.isDefined(testKeyValueCache.remove);
   });
 
-  it("Test put method with params", async () => {
+  it("Test put method with params", async function() {
     const testKeyValueCache = new KeyValueCache();
 
     const response = testKeyValueCache.put("test-key", "test");
     assert.isTrue(response);
   });
 
-  it("Test get method with params", async () => {
+  it("Test get method with params", async function() {
     const testKeyValueCache = new KeyValueCache();
     testKeyValueCache.put("test-key", "test");
 
@@ -53,7 +53,7 @@ describe("KeyValueCache", () => {
     assert.isDefined(response);
   });
 
-  it("Test remove method with params", async () => {
+  it("Test remove method with params", async function() {
     const testKeyValueCache = new KeyValueCache();
     testKeyValueCache.put("test-key", "test");
     testKeyValueCache.put("test-key2", "test");

--- a/tests/integration/api-breaks/LayerVersionsRequest.test.ts
+++ b/tests/integration/api-breaks/LayerVersionsRequest.test.ts
@@ -26,7 +26,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("LayerVersionsRequest", () => {
+describe("LayerVersionsRequest", function() {
   class LayerVersionsRequestTest extends LayerVersionsRequest {
     getVersion(): number {
       return 5;
@@ -45,7 +45,7 @@ describe("LayerVersionsRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new LayerVersionsRequestTest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(LayerVersionsRequest);
@@ -57,14 +57,14 @@ describe("LayerVersionsRequest", () => {
     assert.isFunction(request.getBillingTag);
   });
 
-  it("Test withVersion method with version", async () => {
+  it("Test withVersion method with version", async function() {
     const request = new LayerVersionsRequestTest();
 
     const response = request.withVersion(11);
     assert.isDefined(response);
   });
 
-  it("Test getVersion method without params", async () => {
+  it("Test getVersion method without params", async function() {
     const request = new LayerVersionsRequestTest();
     request.withVersion(11);
 
@@ -72,14 +72,14 @@ describe("LayerVersionsRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const request = new LayerVersionsRequestTest();
 
     const response = request.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const request = new LayerVersionsRequestTest();
     request.withBillingTag("test-tag");
 

--- a/tests/integration/api-breaks/LookupApi.test.ts
+++ b/tests/integration/api-breaks/LookupApi.test.ts
@@ -32,8 +32,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("LookupApi", () => {
-  it("API with all required params", () => {
+describe("LookupApi", function() {
+  it("API with all required params", function() {
     const params: API = {
       api: "test",
       version: "test",
@@ -43,7 +43,7 @@ describe("LookupApi", () => {
     assert.isDefined(params);
   });
 
-  it("API with all required and optional params", () => {
+  it("API with all required and optional params", function() {
     const params: API = {
       api: "test",
       version: "test",
@@ -54,13 +54,13 @@ describe("LookupApi", () => {
     assert.isDefined(params);
   });
 
-  it("ApiNotFoundError with all required params", () => {
+  it("ApiNotFoundError with all required params", function() {
     const params: ApiNotFoundError = {};
 
     assert.isDefined(params);
   });
 
-  it("ApiNotFoundError with all required and optional params", () => {
+  it("ApiNotFoundError with all required and optional params", function() {
     const params: ApiNotFoundError = {
       status: 1,
       title: "test",
@@ -72,7 +72,7 @@ describe("LookupApi", () => {
     assert.isDefined(params);
   });
 
-  it("Test platformAPI method with all required params", async () => {
+  it("Test platformAPI method with all required params", async function() {
     const params = {
       api: "mocked-api",
       version: "mocked-version"
@@ -83,19 +83,19 @@ describe("LookupApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test platformAPIList method without params", async () => {
+  it("Test platformAPIList method without params", async function() {
     const result = await LookupApi.platformAPIList(mockedRequestBuilder);
 
     expect(result).to.be.equal("success");
   });
 
-  it("Test getPlatformAPIList method without params", async () => {
+  it("Test getPlatformAPIList method without params", async function() {
     const result = await LookupApi.getPlatformAPIList(mockedRequestBuilder);
 
     expect(result).to.be.equal("success");
   });
 
-  it("Test resourceAPI method with all required params", async () => {
+  it("Test resourceAPI method with all required params", async function() {
     const params = {
       hrn: "mocked-hrn",
       api: "test",
@@ -107,7 +107,7 @@ describe("LookupApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test resourceAPI method with all required and optional params", async () => {
+  it("Test resourceAPI method with all required and optional params", async function() {
     const params = {
       hrn: "mocked-hrn",
       api: "test",
@@ -120,7 +120,7 @@ describe("LookupApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test resourceAPIList method with all required params", async () => {
+  it("Test resourceAPIList method with all required params", async function() {
     const params = {
       hrn: "mocked-hrn"
     };
@@ -133,7 +133,7 @@ describe("LookupApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test resourceAPIList method with all required and optional params", async () => {
+  it("Test resourceAPIList method with all required and optional params", async function() {
     const params = {
       hrn: "mocked-hrn",
       region: "mocked-region"
@@ -147,7 +147,7 @@ describe("LookupApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getResourceAPIList method with all required params", async () => {
+  it("Test getResourceAPIList method with all required params", async function() {
     const params = {
       hrn: "mocked-hrn"
     };
@@ -160,7 +160,7 @@ describe("LookupApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getResourceAPIList method with all required and optional params", async () => {
+  it("Test getResourceAPIList method with all required and optional params", async function() {
     const params = {
       hrn: "mocked-hrn",
       region: "mocked-region"

--- a/tests/integration/api-breaks/MetadataApi.test.ts
+++ b/tests/integration/api-breaks/MetadataApi.test.ts
@@ -38,8 +38,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("MetadataApi", () => {
-  it("LayerVersion with all required params", () => {
+describe("MetadataApi", function() {
+  it("LayerVersion with all required params", function() {
     const params: LayerVersion = {
       layer: "test",
       version: 1,
@@ -49,7 +49,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("LayerVersion with all required and optional params", () => {
+  it("LayerVersion with all required and optional params", function() {
     const params: LayerVersion = {
       layer: "test",
       version: 1,
@@ -59,7 +59,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("LayerVersions with all required params", () => {
+  it("LayerVersions with all required params", function() {
     const params: LayerVersions = {
       layerVersions: [
         {
@@ -74,7 +74,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("LayerVersions with all required and optional params", () => {
+  it("LayerVersions with all required and optional params", function() {
     const params: LayerVersions = {
       layerVersions: [
         {
@@ -89,7 +89,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("Partition with all required params", () => {
+  it("Partition with all required params", function() {
     const params: Partition = {
       dataHandle: "test",
       partition: "test",
@@ -99,7 +99,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("Partition with all required and optional params", () => {
+  it("Partition with all required and optional params", function() {
     const params: Partition = {
       checksum: "test",
       compressedDataSize: 1,
@@ -112,7 +112,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("Partitions with all required params", () => {
+  it("Partitions with all required params", function() {
     const params: Partitions = {
       partitions: [
         {
@@ -129,7 +129,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("Partitions with all required and optional params", () => {
+  it("Partitions with all required and optional params", function() {
     const params: Partitions = {
       partitions: [
         {
@@ -147,7 +147,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("VersionDependency with all required params", () => {
+  it("VersionDependency with all required params", function() {
     const params: VersionDependency = {
       direct: true,
       hrn: "test",
@@ -157,7 +157,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("VersionDependency with all required and optional params", () => {
+  it("VersionDependency with all required and optional params", function() {
     const params: VersionDependency = {
       direct: true,
       hrn: "test",
@@ -167,7 +167,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("VersionInfo with all required params", () => {
+  it("VersionInfo with all required params", function() {
     const params: VersionInfo = {
       dependencies: [
         {
@@ -184,7 +184,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("VersionInfo with all required and optional params", () => {
+  it("VersionInfo with all required and optional params", function() {
     const params: VersionInfo = {
       dependencies: [
         {
@@ -201,7 +201,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("VersionInfos with all required params", () => {
+  it("VersionInfos with all required params", function() {
     const params: VersionInfos = {
       versions: [
         {
@@ -222,7 +222,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("VersionInfos with all required and optional params", () => {
+  it("VersionInfos with all required and optional params", function() {
     const params: VersionInfos = {
       versions: [
         {
@@ -243,7 +243,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("VersionResponse with all required params", () => {
+  it("VersionResponse with all required params", function() {
     const params: VersionResponse = {
       version: 1
     };
@@ -251,7 +251,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("VersionResponse with all required and optional params", () => {
+  it("VersionResponse with all required and optional params", function() {
     const params: VersionResponse = {
       version: 1
     };
@@ -259,7 +259,7 @@ describe("MetadataApi", () => {
     assert.isDefined(params);
   });
 
-  it("Test getChanges method with all required params", async () => {
+  it("Test getChanges method with all required params", async function() {
     const params = {
       layerId: "test"
     };
@@ -269,7 +269,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getChanges method with all required and optional params", async () => {
+  it("Test getChanges method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       startVersion: 1,
@@ -285,7 +285,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getLayerVersions method with all required params", async () => {
+  it("Test getLayerVersions method with all required params", async function() {
     const params = {
       version: 1
     };
@@ -298,7 +298,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getLayerVersions method with all required and optional params", async () => {
+  it("Test getLayerVersions method with all required and optional params", async function() {
     const params = {
       version: 1,
       billingTag: "test"
@@ -312,7 +312,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getPartitions method with all required params", async () => {
+  it("Test getPartitions method with all required params", async function() {
     const params = {
       layerId: "test"
     };
@@ -325,7 +325,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getPartitions method with all required and optional params", async () => {
+  it("Test getPartitions method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       version: 1,
@@ -342,7 +342,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test latestVersion method with all required params", async () => {
+  it("Test latestVersion method with all required params", async function() {
     const params = {
       startVersion: 1
     };
@@ -355,7 +355,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test latestVersion method with all required and optional params", async () => {
+  it("Test latestVersion method with all required and optional params", async function() {
     const params = {
       startVersion: 1,
       billingTag: "test"
@@ -369,7 +369,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test listVersions method with all required params", async () => {
+  it("Test listVersions method with all required params", async function() {
     const params = {
       startVersion: 1,
       endVersion: 1
@@ -380,7 +380,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test listVersions method with all required and optional params", async () => {
+  it("Test listVersions method with all required and optional params", async function() {
     const params = {
       startVersion: 1,
       endVersion: 1,
@@ -392,7 +392,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test minimumVersion method with all required params", async () => {
+  it("Test minimumVersion method with all required params", async function() {
     const params = {};
 
     const result = await MetadataApi.minimumVersion(
@@ -403,7 +403,7 @@ describe("MetadataApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test minimumVersion method with all required and optional params", async () => {
+  it("Test minimumVersion method with all required and optional params", async function() {
     const params = {
       billingTag: "test"
     };

--- a/tests/integration/api-breaks/PartitionsRequest.test.ts
+++ b/tests/integration/api-breaks/PartitionsRequest.test.ts
@@ -27,7 +27,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("PartitionsRequest", () => {
+describe("PartitionsRequest", function() {
   class PartitionsRequestTest extends PartitionsRequest {
     withVersion(version?: number): PartitionsRequest {
       return this;
@@ -63,7 +63,7 @@ describe("PartitionsRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new PartitionsRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(PartitionsRequest);
@@ -78,63 +78,63 @@ describe("PartitionsRequest", () => {
     assert.isFunction(request.getAdditionalFields);
   });
 
-  it("Test withVersion method with version", async () => {
+  it("Test withVersion method with version", async function() {
     const request = new PartitionsRequestTest();
 
     const response = request.withVersion(5);
     assert.isDefined(response);
   });
 
-  it("Test withVersion method without params", async () => {
+  it("Test withVersion method without params", async function() {
     const request = new PartitionsRequestTest();
 
     const response = request.withVersion();
     assert.isDefined(response);
   });
 
-  it("Test getVersion method without params", async () => {
+  it("Test getVersion method without params", async function() {
     const request = new PartitionsRequestTest();
 
     const response = request.getVersion();
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const request = new PartitionsRequestTest();
 
     const response = request.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const request = new PartitionsRequestTest();
 
     const response = request.getBillingTag();
     assert.isDefined(response);
   });
 
-  it("Test withPartitionIds method with ids", async () => {
+  it("Test withPartitionIds method with ids", async function() {
     const request = new PartitionsRequestTest();
 
     const response = request.withPartitionIds(["test"]);
     assert.isDefined(response);
   });
 
-  it("Test getPartitionIds method without params", async () => {
+  it("Test getPartitionIds method without params", async function() {
     const request = new PartitionsRequestTest();
 
     const response = request.getPartitionIds();
     assert.isDefined(response);
   });
 
-  it("Test withAdditionalFields method with AdditionalFields", async () => {
+  it("Test withAdditionalFields method with AdditionalFields", async function() {
     const request = new PartitionsRequestTest();
 
     const response = request.withAdditionalFields(["dataSize"]);
     assert.isDefined(response);
   });
 
-  it("Test getAdditionalFields method without params", async () => {
+  it("Test getAdditionalFields method without params", async function() {
     const request = new PartitionsRequestTest();
 
     const response = request.getAdditionalFields();

--- a/tests/integration/api-breaks/PollRequest.test.ts
+++ b/tests/integration/api-breaks/PollRequest.test.ts
@@ -26,7 +26,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("PollRequest", () => {
+describe("PollRequest", function() {
   class PollRequestTest extends PollRequest {
     getMode(): "serial" {
       return "serial";
@@ -45,7 +45,7 @@ describe("PollRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new PollRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(PollRequest);
@@ -56,28 +56,28 @@ describe("PollRequest", () => {
     assert.isFunction(request.getSubscriptionId);
   });
 
-  it("Test withMode method with mode", async () => {
+  it("Test withMode method with mode", async function() {
     const request = new PollRequestTest();
 
     const response = request.withMode("serial");
     assert.isDefined(response);
   });
 
-  it("Test getMode method without params", async () => {
+  it("Test getMode method without params", async function() {
     const request = new PollRequestTest();
 
     const response = request.getMode();
     assert.isDefined(response);
   });
 
-  it("Test withSubscriptionId method with id", async () => {
+  it("Test withSubscriptionId method with id", async function() {
     const request = new PollRequestTest();
 
     const response = request.withSubscriptionId("test");
     assert.isDefined(response);
   });
 
-  it("Test getSubscriptionId method without params", async () => {
+  it("Test getSubscriptionId method without params", async function() {
     const request = new PollRequestTest();
 
     const response = request.getSubscriptionId();

--- a/tests/integration/api-breaks/QuadKeyPartitionsRequest.test.ts
+++ b/tests/integration/api-breaks/QuadKeyPartitionsRequest.test.ts
@@ -31,7 +31,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("QuadKeyPartitionsRequest", () => {
+describe("QuadKeyPartitionsRequest", function() {
   class QuadKeyPartitionsRequestTest extends QuadKeyPartitionsRequest {
     withVersion(version?: number): QuadKeyPartitionsRequest {
       return this;
@@ -80,7 +80,7 @@ describe("QuadKeyPartitionsRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new QuadKeyPartitionsRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(QuadKeyPartitionsRequest);
@@ -97,42 +97,42 @@ describe("QuadKeyPartitionsRequest", () => {
     assert.isFunction(request.getAdditionalFields);
   });
 
-  it("Test withVersion method with version", async () => {
+  it("Test withVersion method with version", async function() {
     const request = new QuadKeyPartitionsRequestTest();
 
     const response = request.withVersion(3);
     assert.isDefined(response);
   });
 
-  it("Test withVersion method without params", async () => {
+  it("Test withVersion method without params", async function() {
     const request = new QuadKeyPartitionsRequestTest();
 
     const response = request.withVersion();
     assert.isDefined(response);
   });
 
-  it("Test getVersion method without params", async () => {
+  it("Test getVersion method without params", async function() {
     const request = new QuadKeyPartitionsRequestTest();
 
     const response = request.getVersion();
     assert.isDefined(response);
   });
 
-  it("Test withDepth method with depth", async () => {
+  it("Test withDepth method with depth", async function() {
     const request = new QuadKeyPartitionsRequestTest();
 
     const response = request.withDepth(3);
     assert.isDefined(response);
   });
 
-  it("Test getDepth method without params", async () => {
+  it("Test getDepth method without params", async function() {
     const request = new QuadKeyPartitionsRequestTest();
 
     const response = request.getDepth();
     assert.isDefined(response);
   });
 
-  it("Test withQuadKey method with quadKey", async () => {
+  it("Test withQuadKey method with quadKey", async function() {
     const request = new QuadKeyPartitionsRequestTest();
 
     const response = request.withQuadKey({
@@ -143,35 +143,35 @@ describe("QuadKeyPartitionsRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getQuadKey method without params", async () => {
+  it("Test getQuadKey method without params", async function() {
     const request = new QuadKeyPartitionsRequestTest();
 
     const response = request.getQuadKey();
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const catalogRequest = new QuadKeyPartitionsRequestTest();
 
     const response = catalogRequest.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const catalogRequest = new QuadKeyPartitionsRequestTest();
 
     const response = catalogRequest.getBillingTag();
     assert.isDefined(response);
   });
 
-  it("Test withAdditionalFields method with additionalFields", async () => {
+  it("Test withAdditionalFields method with additionalFields", async function() {
     const catalogRequest = new QuadKeyPartitionsRequestTest();
 
     const response = catalogRequest.withAdditionalFields(["dataSize"]);
     assert.isDefined(response);
   });
 
-  it("Test getAdditionalFields method without params", async () => {
+  it("Test getAdditionalFields method without params", async function() {
     const catalogRequest = new QuadKeyPartitionsRequestTest();
 
     const response = catalogRequest.getAdditionalFields();

--- a/tests/integration/api-breaks/QuadTreeIndexRequest.test.ts
+++ b/tests/integration/api-breaks/QuadTreeIndexRequest.test.ts
@@ -32,7 +32,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("QuadTreeIndexRequest", () => {
+describe("QuadTreeIndexRequest", function() {
   class QuadTreeIndexRequestTest extends QuadTreeIndexRequest {
     withVersion(version?: number): QuadTreeIndexRequest {
       return this;
@@ -81,7 +81,7 @@ describe("QuadTreeIndexRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new QuadTreeIndexRequest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -94,7 +94,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isFunction(request.getBillingTag);
   });
 
-  it("Test withVersion method with version", async () => {
+  it("Test withVersion method with version", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -105,7 +105,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test withVersion method without params", async () => {
+  it("Test withVersion method without params", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -116,7 +116,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getVersion method without params", async () => {
+  it("Test getVersion method without params", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -127,7 +127,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test withDepth method with depth", async () => {
+  it("Test withDepth method with depth", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -138,7 +138,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getDepth method without params", async () => {
+  it("Test getDepth method without params", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -149,7 +149,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test withQuadKey method with quadKey", async () => {
+  it("Test withQuadKey method with quadKey", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -164,7 +164,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getQuadKey method without params", async () => {
+  it("Test getQuadKey method without params", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -175,7 +175,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -186,7 +186,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -197,7 +197,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test withAdditionalFields method with additionalFields", async () => {
+  it("Test withAdditionalFields method with additionalFields", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",
@@ -208,7 +208,7 @@ describe("QuadTreeIndexRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getAdditionalFields method without params", async () => {
+  it("Test getAdditionalFields method without params", async function() {
     const request = new QuadTreeIndexRequestTest(
       HRN.fromString("hrn:here:data:::test-hrn"),
       "id",

--- a/tests/integration/api-breaks/QueryApi.test.ts
+++ b/tests/integration/api-breaks/QueryApi.test.ts
@@ -35,14 +35,14 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("QueryApi", () => {
-  it("Index with all required params", () => {
+describe("QueryApi", function() {
+  it("Index with all required params", function() {
     const params: Index = {};
 
     assert.isDefined(params);
   });
 
-  it("Index with all required and optional params", () => {
+  it("Index with all required and optional params", function() {
     const params: Index = {
       parentQuads: [
         {
@@ -73,7 +73,7 @@ describe("QueryApi", () => {
     assert.isDefined(params);
   });
 
-  it("ParentQuad with all required params", () => {
+  it("ParentQuad with all required params", function() {
     const params: ParentQuad = {
       dataHandle: "test",
       partition: "test",
@@ -83,7 +83,7 @@ describe("QueryApi", () => {
     assert.isDefined(params);
   });
 
-  it("ParentQuad with all required and optional params", () => {
+  it("ParentQuad with all required and optional params", function() {
     const params: ParentQuad = {
       additionalMetadata: "test",
       checksum: "test",
@@ -97,7 +97,7 @@ describe("QueryApi", () => {
     assert.isDefined(params);
   });
 
-  it("Partition with all required params", () => {
+  it("Partition with all required params", function() {
     const params: Partition = {
       partition: "test",
       version: 1
@@ -106,7 +106,7 @@ describe("QueryApi", () => {
     assert.isDefined(params);
   });
 
-  it("Partition with all required and optional params", () => {
+  it("Partition with all required and optional params", function() {
     const params: Partition = {
       checksum: "test",
       compressedDataSize: 1,
@@ -119,13 +119,13 @@ describe("QueryApi", () => {
     assert.isDefined(params);
   });
 
-  it("Partitions with all required params", () => {
+  it("Partitions with all required params", function() {
     const params: Partitions = {};
 
     assert.isDefined(params);
   });
 
-  it("Partitions with all required and optional params", () => {
+  it("Partitions with all required and optional params", function() {
     const params: Partitions = {
       partitions: [
         {
@@ -144,7 +144,7 @@ describe("QueryApi", () => {
     assert.isDefined(params);
   });
 
-  it("SubQuad with all required params", () => {
+  it("SubQuad with all required params", function() {
     const params: SubQuad = {
       dataHandle: "test",
       subQuadKey: "test",
@@ -154,7 +154,7 @@ describe("QueryApi", () => {
     assert.isDefined(params);
   });
 
-  it("SubQuad with all required and optional params", () => {
+  it("SubQuad with all required and optional params", function() {
     const params: SubQuad = {
       additionalMetadata: "test",
       checksum: "test",
@@ -168,7 +168,7 @@ describe("QueryApi", () => {
     assert.isDefined(params);
   });
 
-  it("Test getChangesById method with all required params", async () => {
+  it("Test getChangesById method with all required params", async function() {
     const params = {
       layerId: "test",
       partition: ["test"]
@@ -179,7 +179,7 @@ describe("QueryApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getChangesById method with all required and optional params", async () => {
+  it("Test getChangesById method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       partition: ["test"],
@@ -195,7 +195,7 @@ describe("QueryApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getPartitionsById method with all required params", async () => {
+  it("Test getPartitionsById method with all required params", async function() {
     const params = {
       layerId: "test",
       partition: ["test"]
@@ -209,7 +209,7 @@ describe("QueryApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getPartitionsById method with all required and optional params", async () => {
+  it("Test getPartitionsById method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       partition: ["test"],
@@ -226,7 +226,7 @@ describe("QueryApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test quadTreeIndex method with all required params", async () => {
+  it("Test quadTreeIndex method with all required params", async function() {
     const params = {
       layerId: "test",
       version: 1,
@@ -239,7 +239,7 @@ describe("QueryApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test quadTreeIndex method with all required and optional params", async () => {
+  it("Test quadTreeIndex method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       version: 1,
@@ -254,7 +254,7 @@ describe("QueryApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test quadTreeIndexVolatile method with all required params", async () => {
+  it("Test quadTreeIndexVolatile method with all required params", async function() {
     const params = {
       layerId: "test",
       quadKey: "test",
@@ -269,7 +269,7 @@ describe("QueryApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test quadTreeIndexVolatile method with all required and optional params", async () => {
+  it("Test quadTreeIndexVolatile method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       quadKey: "test",

--- a/tests/integration/api-breaks/QueryClient.test.ts
+++ b/tests/integration/api-breaks/QueryClient.test.ts
@@ -29,7 +29,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("QueryClient", () => {
+describe("QueryClient", function() {
   class QueryClientTest extends QueryClient {
     constructor(settings: OlpClientSettings) {
       super(settings);
@@ -67,7 +67,7 @@ describe("QueryClient", () => {
     "hrn:here:data:::mocked-hrn"
   );
 
-  it("Shoud be initialized with arguments", async () => {
+  it("Shoud be initialized with arguments", async function() {
     const queryClient = new QueryClient(settings);
     assert.isDefined(queryClient);
 
@@ -76,7 +76,7 @@ describe("QueryClient", () => {
     assert.isDefined(queryClient.getPartitionsById);
   });
 
-  it("Test fetchQuadTreeIndex method with required params", async () => {
+  it("Test fetchQuadTreeIndex method with required params", async function() {
     const client = new QueryClientTest(settings);
 
     const response = await client.fetchQuadTreeIndex(
@@ -85,7 +85,7 @@ describe("QueryClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test fetchQuadTreeIndex method with required and optional params", async () => {
+  it("Test fetchQuadTreeIndex method with required and optional params", async function() {
     const client = new QueryClientTest(settings);
 
     const response = await client.fetchQuadTreeIndex(
@@ -95,7 +95,7 @@ describe("QueryClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getPartitionsById method with required params", async () => {
+  it("Test getPartitionsById method with required params", async function() {
     const client = new QueryClientTest(settings);
 
     const response = await client.getPartitionsById(
@@ -106,7 +106,7 @@ describe("QueryClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getPartitionsById method with required and optional params", async () => {
+  it("Test getPartitionsById method with required and optional params", async function() {
     const client = new QueryClientTest(settings);
 
     const response = await client.getPartitionsById(

--- a/tests/integration/api-breaks/SchemaDetailsRequest.test.ts
+++ b/tests/integration/api-breaks/SchemaDetailsRequest.test.ts
@@ -26,7 +26,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SchemaDetailsRequest", () => {
+describe("SchemaDetailsRequest", function() {
   class SchemaDetailsRequestTest extends SchemaDetailsRequest {
     getSchema(): HRN {
       return HRN.fromString("hrn:here:data:::test-hrn");
@@ -45,7 +45,7 @@ describe("SchemaDetailsRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new SchemaDetailsRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(SchemaDetailsRequest);
@@ -56,7 +56,7 @@ describe("SchemaDetailsRequest", () => {
     assert.isFunction(request.getBillingTag);
   });
 
-  it("Test withSchema method with schema", async () => {
+  it("Test withSchema method with schema", async function() {
     const request = new SchemaDetailsRequestTest();
 
     const response = request.withSchema(
@@ -65,21 +65,21 @@ describe("SchemaDetailsRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getSchema method without params", async () => {
+  it("Test getSchema method without params", async function() {
     const request = new SchemaDetailsRequestTest();
 
     const response = request.getSchema();
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const request = new SchemaDetailsRequestTest();
 
     const response = request.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const request = new SchemaDetailsRequestTest();
 
     const response = request.getBillingTag();

--- a/tests/integration/api-breaks/SchemaRequest.test.ts
+++ b/tests/integration/api-breaks/SchemaRequest.test.ts
@@ -27,7 +27,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SchemaRequest", () => {
+describe("SchemaRequest", function() {
   class SchemaRequestTest extends SchemaRequest {
     getVariant(): ArtifactApi.Variant {
       return {
@@ -49,7 +49,7 @@ describe("SchemaRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new SchemaRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(SchemaRequest);
@@ -60,7 +60,7 @@ describe("SchemaRequest", () => {
     assert.isFunction(request.getBillingTag);
   });
 
-  it("Test withVariant method with variant", async () => {
+  it("Test withVariant method with variant", async function() {
     const request = new SchemaRequestTest();
 
     const response = request.withVariant({
@@ -70,21 +70,21 @@ describe("SchemaRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getVariant method without params", async () => {
+  it("Test getVariant method without params", async function() {
     const request = new SchemaRequestTest();
 
     const response = request.getVariant();
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const request = new SchemaRequestTest();
 
     const response = request.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const request = new SchemaRequestTest();
 
     const response = request.getBillingTag();

--- a/tests/integration/api-breaks/SeekRequest.test.ts
+++ b/tests/integration/api-breaks/SeekRequest.test.ts
@@ -27,7 +27,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SeekRequest", () => {
+describe("SeekRequest", function() {
   class SeekRequestTest extends SeekRequest {
     getMode(): "serial" {
       return "serial";
@@ -61,7 +61,7 @@ describe("SeekRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new SeekRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(SeekRequest);
@@ -74,35 +74,35 @@ describe("SeekRequest", () => {
     assert.isFunction(request.getSeekOffsets);
   });
 
-  it("Test withMode method with mode", async () => {
+  it("Test withMode method with mode", async function() {
     const request = new SeekRequestTest();
 
     const response = request.withMode("serial");
     assert.isDefined(response);
   });
 
-  it("Test getMode method without params", async () => {
+  it("Test getMode method without params", async function() {
     const request = new SeekRequestTest();
 
     const response = request.getMode();
     assert.isDefined(response);
   });
 
-  it("Test withSubscriptionId method with id", async () => {
+  it("Test withSubscriptionId method with id", async function() {
     const request = new SeekRequestTest();
 
     const response = request.withSubscriptionId("test");
     assert.isDefined(response);
   });
 
-  it("Test getSubscriptionId method without params", async () => {
+  it("Test getSubscriptionId method without params", async function() {
     const request = new SeekRequestTest();
 
     const response = request.getSubscriptionId();
     assert.isDefined(response);
   });
 
-  it("Test withSeekOffsets method with offsets", async () => {
+  it("Test withSeekOffsets method with offsets", async function() {
     const request = new SeekRequestTest();
 
     const response = request.withSeekOffsets({
@@ -116,7 +116,7 @@ describe("SeekRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getSeekOffsets method without params", async () => {
+  it("Test getSeekOffsets method without params", async function() {
     const request = new SeekRequestTest();
 
     const response = request.getSeekOffsets();

--- a/tests/integration/api-breaks/StatisticsClient.test.ts
+++ b/tests/integration/api-breaks/StatisticsClient.test.ts
@@ -32,7 +32,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("StatisticsClient", () => {
+describe("StatisticsClient", function() {
   class StatisticsClientTest extends StatisticsClient {
     constructor(settings: OlpClientSettings) {
       super(settings);
@@ -76,7 +76,7 @@ describe("StatisticsClient", () => {
     getToken: () => Promise.resolve("mocked-token")
   });
 
-  it("Shoud be initialized with arguments", async () => {
+  it("Shoud be initialized with arguments", async function() {
     const client = new StatisticsClient(settings);
     assert.isDefined(client);
 
@@ -85,7 +85,7 @@ describe("StatisticsClient", () => {
     assert.isDefined(client.getStatistics);
   });
 
-  it("Test getSummary method with summaryRequest", async () => {
+  it("Test getSummary method with summaryRequest", async function() {
     const client = new StatisticsClientTest(settings);
 
     const response = await client.getSummary(
@@ -94,7 +94,7 @@ describe("StatisticsClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getStatistics method with statisticsRequest", async () => {
+  it("Test getStatistics method with statisticsRequest", async function() {
     const client = new StatisticsClientTest(settings);
 
     const response = await client.getStatistics(

--- a/tests/integration/api-breaks/StatisticsRequest.test.ts
+++ b/tests/integration/api-breaks/StatisticsRequest.test.ts
@@ -27,7 +27,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("StatisticsRequest", () => {
+describe("StatisticsRequest", function() {
   enum CoverageDataType {
     BITMAP = "tilemap",
     SIZEMAP = "heatmap/size",
@@ -91,7 +91,7 @@ describe("StatisticsRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new StatisticsRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(StatisticsRequest);
@@ -110,21 +110,21 @@ describe("StatisticsRequest", () => {
     assert.isFunction(request.getBillingTag);
   });
 
-  it("Test withTypemap method with type map", async () => {
+  it("Test withTypemap method with type map", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.withTypemap(CoverageDataType.BITMAP);
     assert.isDefined(response);
   });
 
-  it("Test getTypemap method without params", async () => {
+  it("Test getTypemap method without params", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.getTypemap();
     assert.isDefined(response);
   });
 
-  it("Test withCatalogHrn method with hrn", async () => {
+  it("Test withCatalogHrn method with hrn", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.withCatalogHrn(
@@ -133,49 +133,49 @@ describe("StatisticsRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getCatalogHrn method without params", async () => {
+  it("Test getCatalogHrn method without params", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.getCatalogHrn();
     assert.isDefined(response);
   });
 
-  it("Test withDataLevel method with dataLevel", async () => {
+  it("Test withDataLevel method with dataLevel", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.withDataLevel(1);
     assert.isDefined(response);
   });
 
-  it("Test getDataLevel method without params", async () => {
+  it("Test getDataLevel method without params", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.getDataLevel();
     assert.isDefined(response);
   });
 
-  it("Test withLayerId method with layerId", async () => {
+  it("Test withLayerId method with layerId", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.withLayerId("test");
     assert.isDefined(response);
   });
 
-  it("Test getLayerId method without params", async () => {
+  it("Test getLayerId method without params", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.getLayerId();
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.withBillingTag("test-tag");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const request = new StatisticsRequestTest();
 
     const response = request.getBillingTag();

--- a/tests/integration/api-breaks/StreamApi.test.ts
+++ b/tests/integration/api-breaks/StreamApi.test.ts
@@ -43,8 +43,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("StreamApi", () => {
-  it("BootstrapServer with all required params", () => {
+describe("StreamApi", function() {
+  it("BootstrapServer with all required params", function() {
     const params: BootstrapServer = {
       hostname: "test",
       port: 1
@@ -53,13 +53,13 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("CommitOffsetsRequest with all required params", () => {
+  it("CommitOffsetsRequest with all required params", function() {
     const params: CommitOffsetsRequest = {};
 
     assert.isDefined(params);
   });
 
-  it("CommitOffsetsRequest with all required and optional params", () => {
+  it("CommitOffsetsRequest with all required and optional params", function() {
     const params: CommitOffsetsRequest = {
       offsets: [
         {
@@ -72,7 +72,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("ConsumeDataResponse with all required params", () => {
+  it("ConsumeDataResponse with all required params", function() {
     const params: ConsumeDataResponse = {
       messages: [
         {
@@ -96,13 +96,13 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("ConsumerSubscribeResponse with all required params", () => {
+  it("ConsumerSubscribeResponse with all required params", function() {
     const params: ConsumerSubscribeResponse = {};
 
     assert.isDefined(params);
   });
 
-  it("ConsumerSubscribeResponse with all required and optional params", () => {
+  it("ConsumerSubscribeResponse with all required and optional params", function() {
     const params: ConsumerSubscribeResponse = {
       nodeBaseURL: "test",
       subscriptionId: "test"
@@ -111,7 +111,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("ErrorResponse with all required params", () => {
+  it("ErrorResponse with all required params", function() {
     const params: ErrorResponse = {
       title: "test",
       status: 1,
@@ -124,13 +124,13 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("InlineResponse401 with all required params", () => {
+  it("InlineResponse401 with all required params", function() {
     const params: InlineResponse401 = {};
 
     assert.isDefined(params);
   });
 
-  it("InlineResponse401 with all required and optional params", () => {
+  it("InlineResponse401 with all required and optional params", function() {
     const params: InlineResponse401 = {
       error: "test",
       errorDescription: "test"
@@ -139,13 +139,13 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("InlineResponse403  with all required params", () => {
+  it("InlineResponse403  with all required params", function() {
     const params: InlineResponse403 = {};
 
     assert.isDefined(params);
   });
 
-  it("InlineResponse403  with all required and optional params", () => {
+  it("InlineResponse403  with all required and optional params", function() {
     const params: InlineResponse403 = {
       error: "test",
       errorDescription: "test"
@@ -154,7 +154,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("ConsumerProperties with all required params", () => {
+  it("ConsumerProperties with all required params", function() {
     const params: ConsumerProperties = {
       ["test"]: "test"
     };
@@ -162,7 +162,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("Message with all required params", () => {
+  it("Message with all required params", function() {
     const params: Message = {
       metaData: {
         partition: "test",
@@ -182,7 +182,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("Metadata with all required params", () => {
+  it("Metadata with all required params", function() {
     const params: Metadata = {
       partition: "test"
     };
@@ -190,7 +190,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("Metadata with all required and optional params", () => {
+  it("Metadata with all required and optional params", function() {
     const params: Metadata = {
       partition: "test",
       checksum: "test",
@@ -204,13 +204,13 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("SeekOffsetsRequest with all required params", () => {
+  it("SeekOffsetsRequest with all required params", function() {
     const params: SeekOffsetsRequest = {};
 
     assert.isDefined(params);
   });
 
-  it("SeekOffsetsRequest with all required and optional params", () => {
+  it("SeekOffsetsRequest with all required and optional params", function() {
     const params: SeekOffsetsRequest = {
       offsets: [
         {
@@ -223,7 +223,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("StreamLayerEndpointResponse with all required params", () => {
+  it("StreamLayerEndpointResponse with all required params", function() {
     const params: StreamLayerEndpointResponse = {
       kafkaProtocolVersion: ["0.10"],
       topic: "test",
@@ -240,7 +240,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("StreamLayerEndpointResponse with all required and optional params", () => {
+  it("StreamLayerEndpointResponse with all required and optional params", function() {
     const params: StreamLayerEndpointResponse = {
       kafkaProtocolVersion: ["0.10"],
       topic: "test",
@@ -263,7 +263,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("StreamOffset with all required params", () => {
+  it("StreamOffset with all required params", function() {
     const params: StreamOffset = {
       partition: 1,
       offset: 1
@@ -272,7 +272,7 @@ describe("StreamApi", () => {
     assert.isDefined(params);
   });
 
-  it("Test commitOffsets method with all required params", async () => {
+  it("Test commitOffsets method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       commitOffsets: {
@@ -290,7 +290,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test commitOffsets method with all required and optional params", async () => {
+  it("Test commitOffsets method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       subscriptionId: "test-subscriptionId",
@@ -310,7 +310,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test doCommitOffsets method with all required params", async () => {
+  it("Test doCommitOffsets method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       commitOffsets: {
@@ -331,7 +331,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test doCommitOffsets method with all required and optional params", async () => {
+  it("Test doCommitOffsets method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       subscriptionId: "test-subscriptionId",
@@ -354,7 +354,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test consumeData method with all required params", async () => {
+  it("Test consumeData method with all required params", async function() {
     const params = {
       layerId: "mocked-id"
     };
@@ -364,7 +364,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test consumeData method with all required and optional params", async () => {
+  it("Test consumeData method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       subscriptionId: "test-subscriptionId",
@@ -376,7 +376,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteSubscription method with all required params", async () => {
+  it("Test deleteSubscription method with all required params", async function() {
     const params = {
       layerId: "mocked-id"
     };
@@ -389,7 +389,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteSubscription method with all required and optional params", async () => {
+  it("Test deleteSubscription method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       subscriptionId: "test-subscriptionId",
@@ -404,7 +404,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test endpoint method with all required params", async () => {
+  it("Test endpoint method with all required params", async function() {
     const params = {
       layerId: "mocked-id"
     };
@@ -414,7 +414,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test seekToOffset method with all required params", async () => {
+  it("Test seekToOffset method with all required params", async function() {
     const params = {
       layerId: "mocked-id",
       seekOffsets: {
@@ -432,7 +432,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test seekToOffset method with all required and optional params", async () => {
+  it("Test seekToOffset method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       seekOffsets: {
@@ -452,7 +452,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test subscribe method with all required params", async () => {
+  it("Test subscribe method with all required params", async function() {
     const params = {
       layerId: "mocked-id"
     };
@@ -462,7 +462,7 @@ describe("StreamApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test subscribe method with all required and optional params", async () => {
+  it("Test subscribe method with all required and optional params", async function() {
     const params = {
       layerId: "mocked-id",
       subscriptionId: "testSubsId",

--- a/tests/integration/api-breaks/StreamLayerClient.test.ts
+++ b/tests/integration/api-breaks/StreamLayerClient.test.ts
@@ -36,8 +36,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("StreamLayerClientParams", () => {
-  it("StreamLayerClientParams with all required params", () => {
+describe("StreamLayerClientParams", function() {
+  it("StreamLayerClientParams with all required params", function() {
     const params: StreamLayerClientParams = {
       catalogHrn: HRN.fromString("hrn:here:data:::example-catalog"),
       layerId: "mocked-layer-id",
@@ -51,7 +51,7 @@ describe("StreamLayerClientParams", () => {
   });
 });
 
-describe("StreamLayerClient", () => {
+describe("StreamLayerClient", function() {
   class StreamLayerClientTest extends StreamLayerClient {
     constructor(params: StreamLayerClientParams) {
       super(params);
@@ -93,7 +93,7 @@ describe("StreamLayerClient", () => {
     }
   }
 
-  it("Shoud be initialized with StreamLayerClientParams", async () => {
+  it("Shoud be initialized with StreamLayerClientParams", async function() {
     const layerClient = new StreamLayerClient({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -112,7 +112,7 @@ describe("StreamLayerClient", () => {
     assert.isFunction(layerClient.seek);
   });
 
-  it("Test subscribe method method with SubscribeRequest", async () => {
+  it("Test subscribe method method with SubscribeRequest", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -128,7 +128,7 @@ describe("StreamLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test subscribe method method with SubscribeRequest and abort signal", async () => {
+  it("Test subscribe method method with SubscribeRequest and abort signal", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -149,7 +149,7 @@ describe("StreamLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test poll method method with PollRequest", async () => {
+  it("Test poll method method with PollRequest", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -165,7 +165,7 @@ describe("StreamLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test poll method method with PollRequest and abort signal", async () => {
+  it("Test poll method method with PollRequest and abort signal", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -183,7 +183,7 @@ describe("StreamLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test unsubscribe method method with UnsubscribeRequest", async () => {
+  it("Test unsubscribe method method with UnsubscribeRequest", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -199,7 +199,7 @@ describe("StreamLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test unsubscribe method method with UnsubscribeRequest and abort signal", async () => {
+  it("Test unsubscribe method method with UnsubscribeRequest and abort signal", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -220,7 +220,7 @@ describe("StreamLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getData method method with message", async () => {
+  it("Test getData method method with message", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -242,7 +242,7 @@ describe("StreamLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test getData method method with message and abort signal", async () => {
+  it("Test getData method method with message and abort signal", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -266,7 +266,7 @@ describe("StreamLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test seek method method with SeekRequest", async () => {
+  it("Test seek method method with SeekRequest", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -282,7 +282,7 @@ describe("StreamLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("Test seek method method with SeekRequest and abort signal", async () => {
+  it("Test seek method method with SeekRequest and abort signal", async function() {
     const layerClient = new StreamLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",

--- a/tests/integration/api-breaks/SubscribeRequest.test.ts
+++ b/tests/integration/api-breaks/SubscribeRequest.test.ts
@@ -27,7 +27,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SubscribeRequest", () => {
+describe("SubscribeRequest", function() {
   class SubscribeRequestTest extends SubscribeRequest {
     getMode(): "serial" {
       return "serial";
@@ -66,7 +66,7 @@ describe("SubscribeRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new SubscribeRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(SubscribeRequest);
@@ -81,49 +81,49 @@ describe("SubscribeRequest", () => {
     assert.isFunction(request.getSubscriptionProperties);
   });
 
-  it("Test withMode method with mode", async () => {
+  it("Test withMode method with mode", async function() {
     const request = new SubscribeRequestTest();
 
     const response = request.withMode("serial");
     assert.isDefined(response);
   });
 
-  it("Test getMode method without params", async () => {
+  it("Test getMode method without params", async function() {
     const request = new SubscribeRequestTest();
 
     const response = request.getMode();
     assert.isDefined(response);
   });
 
-  it("Test withSubscriptionId method with id", async () => {
+  it("Test withSubscriptionId method with id", async function() {
     const request = new SubscribeRequestTest();
 
     const response = request.withSubscriptionId("test");
     assert.isDefined(response);
   });
 
-  it("Test getSubscriptionId method without params", async () => {
+  it("Test getSubscriptionId method without params", async function() {
     const request = new SubscribeRequestTest();
 
     const response = request.getSubscriptionId();
     assert.isDefined(response);
   });
 
-  it("Test withConsumerId method with id", async () => {
+  it("Test withConsumerId method with id", async function() {
     const request = new SubscribeRequestTest();
 
     const response = request.withConsumerId("test");
     assert.isDefined(response);
   });
 
-  it("Test getConsumerId method without params", async () => {
+  it("Test getConsumerId method without params", async function() {
     const request = new SubscribeRequestTest();
 
     const response = request.getConsumerId();
     assert.isDefined(response);
   });
 
-  it("Test withSubscriptionProperties method with props", async () => {
+  it("Test withSubscriptionProperties method with props", async function() {
     const request = new SubscribeRequestTest();
 
     const response = request.withSubscriptionProperties({
@@ -132,7 +132,7 @@ describe("SubscribeRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test getSubscriptionProperties method without params", async () => {
+  it("Test getSubscriptionProperties method without params", async function() {
     const request = new SubscribeRequestTest();
 
     const response = request.getSubscriptionProperties();

--- a/tests/integration/api-breaks/SummaryRequest.test.ts
+++ b/tests/integration/api-breaks/SummaryRequest.test.ts
@@ -29,12 +29,12 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("SummaryRequest", () => {
+describe("SummaryRequest", function() {
   const testCatalogHrn = dataServiceRead.HRN.fromString(
     "hrn:here:data:::mocked-hrn"
   );
 
-  it("Shoud be initialized with arguments", async () => {
+  it("Shoud be initialized with arguments", async function() {
     const client = new SummaryRequest();
     assert.isDefined(client);
 
@@ -47,14 +47,14 @@ describe("SummaryRequest", () => {
     assert.isDefined(client.withLayerId);
   });
 
-  it("Test withLayerId method with layerId", async () => {
+  it("Test withLayerId method with layerId", async function() {
     const client = new SummaryRequest();
 
     const response = await client.withLayerId("test");
     assert.isDefined(response);
   });
 
-  it("Test getLayerId method without params", async () => {
+  it("Test getLayerId method without params", async function() {
     const client = new SummaryRequest();
     await client.withLayerId("test");
 
@@ -62,14 +62,14 @@ describe("SummaryRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test withBillingTag method with tag", async () => {
+  it("Test withBillingTag method with tag", async function() {
     const client = new SummaryRequest();
 
     const response = await client.withBillingTag("test");
     assert.isDefined(response);
   });
 
-  it("Test getBillingTag method without params", async () => {
+  it("Test getBillingTag method without params", async function() {
     const client = new SummaryRequest();
     await client.withBillingTag("test");
 
@@ -77,14 +77,14 @@ describe("SummaryRequest", () => {
     assert.isDefined(response);
   });
 
-  it("Test withCatalogHrn method with hrn", async () => {
+  it("Test withCatalogHrn method with hrn", async function() {
     const client = new SummaryRequest();
 
     const response = await client.withCatalogHrn(testCatalogHrn);
     assert.isDefined(response);
   });
 
-  it("Test getCatalogHrn method without params", async () => {
+  it("Test getCatalogHrn method without params", async function() {
     const client = new SummaryRequest();
     await client.withCatalogHrn(testCatalogHrn);
 

--- a/tests/integration/api-breaks/UnsubscribeRequest.test.ts
+++ b/tests/integration/api-breaks/UnsubscribeRequest.test.ts
@@ -26,7 +26,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("UnsubscribeRequest", () => {
+describe("UnsubscribeRequest", function() {
   class UnsubscribeRequestTest extends UnsubscribeRequest {
     getMode(): "serial" {
       return "serial";
@@ -45,7 +45,7 @@ describe("UnsubscribeRequest", () => {
     }
   }
 
-  it("Shoud be initialized", async () => {
+  it("Shoud be initialized", async function() {
     const request = new UnsubscribeRequest();
     assert.isDefined(request);
     expect(request).to.be.instanceOf(UnsubscribeRequest);
@@ -56,28 +56,28 @@ describe("UnsubscribeRequest", () => {
     assert.isFunction(request.getSubscriptionId);
   });
 
-  it("Test withMode method with mode", async () => {
+  it("Test withMode method with mode", async function() {
     const request = new UnsubscribeRequestTest();
 
     const response = request.withMode("serial");
     assert.isDefined(response);
   });
 
-  it("Test getMode method without params", async () => {
+  it("Test getMode method without params", async function() {
     const request = new UnsubscribeRequestTest();
 
     const response = request.getMode();
     assert.isDefined(response);
   });
 
-  it("Test withSubscriptionId method with id", async () => {
+  it("Test withSubscriptionId method with id", async function() {
     const request = new UnsubscribeRequestTest();
 
     const response = request.withSubscriptionId("test");
     assert.isDefined(response);
   });
 
-  it("Test getSubscriptionId method without params", async () => {
+  it("Test getSubscriptionId method without params", async function() {
     const request = new UnsubscribeRequestTest();
 
     const response = request.getSubscriptionId();

--- a/tests/integration/api-breaks/UserAuth.test.ts
+++ b/tests/integration/api-breaks/UserAuth.test.ts
@@ -35,7 +35,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("UserAuth", () => {
+describe("UserAuth", function() {
   class UserAuthTest extends UserAuth {
     constructor(config: UserAuthConfig) {
       super(config);
@@ -68,7 +68,7 @@ describe("UserAuth", () => {
     }
   }
 
-  it("Shoud be initialized with config", async () => {
+  it("Shoud be initialized with config", async function() {
     const credentials = {
       accessKeyId: "test-key",
       accessKeySecret: "test-key-secret"
@@ -87,7 +87,7 @@ describe("UserAuth", () => {
     assert.isFunction(userAuth.getUserInfo);
   });
 
-  it("Should getToken be called without arguments", async () => {
+  it("Should getToken be called without arguments", async function() {
     const credentials = {
       accessKeyId: "test-key",
       accessKeySecret: "test-key-secret"
@@ -103,7 +103,7 @@ describe("UserAuth", () => {
     assert.isDefined(response);
   });
 
-  it("Should validateAccessToken be called with required arguments", async () => {
+  it("Should validateAccessToken be called with required arguments", async function() {
     const credentials = {
       accessKeyId: "test-key",
       accessKeySecret: "test-key-secret"
@@ -119,7 +119,7 @@ describe("UserAuth", () => {
     assert.isDefined(response);
   });
 
-  it("Test getUserInfo method with token", async () => {
+  it("Test getUserInfo method with token", async function() {
     const credentials = {
       accessKeyId: "test-key",
       accessKeySecret: "test-key-secret"
@@ -136,8 +136,8 @@ describe("UserAuth", () => {
   });
 });
 
-describe("AuthCredentials", () => {
-  it("Test AuthCredentials with params", () => {
+describe("AuthCredentials", function() {
+  it("Test AuthCredentials with params", function() {
     const credentials: AuthCredentials = {
       accessKeyId: "test-accessKeyId",
       accessKeySecret: "test-accessKeySecret"
@@ -146,15 +146,15 @@ describe("AuthCredentials", () => {
     assert.isDefined(credentials);
   });
 
-  it("Test AuthCredentials with all required params", () => {
+  it("Test AuthCredentials with all required params", function() {
     const credentials: AuthCredentials = {};
 
     assert.isDefined(credentials);
   });
 });
 
-describe("UserAuthConfig", () => {
-  it("Test UserAuthConfig with params", () => {
+describe("UserAuthConfig", function() {
+  it("Test UserAuthConfig with params", function() {
     const config: UserAuthConfig = {
       credentials: {
         accessKeyId: "test-accessKeyId",
@@ -169,7 +169,7 @@ describe("UserAuthConfig", () => {
     assert.isDefined(config);
   });
 
-  it("Test UserAuthConfig with all required params", () => {
+  it("Test UserAuthConfig with all required params", function() {
     const config: UserAuthConfig = {
       tokenRequester: authentication.requestToken
     };
@@ -178,8 +178,8 @@ describe("UserAuthConfig", () => {
   });
 });
 
-describe("UserInfo", () => {
-  it("Test UserInfo with all required params", () => {
+describe("UserInfo", function() {
+  it("Test UserInfo with all required params", function() {
     const userInfo: UserInfo = {
       userId: "userId",
       realm: "test",
@@ -200,8 +200,8 @@ describe("UserInfo", () => {
   });
 });
 
-describe("Signer", () => {
-  it("Test Signer with all required params", () => {
+describe("Signer", function() {
+  it("Test Signer with all required params", function() {
     const signer: Signer = {
       sign: (data: ArrayBufferLike, secretKey: string) =>
         Promise.resolve("test-response"),
@@ -212,8 +212,8 @@ describe("Signer", () => {
   });
 });
 
-describe("OAuthArgs", () => {
-  it("Test OAuthArgs with params", () => {
+describe("OAuthArgs", function() {
+  it("Test OAuthArgs with params", function() {
     const oAuthArgs: OAuthArgs = {
       url: "test",
       consumerKey: "test",
@@ -226,7 +226,7 @@ describe("OAuthArgs", () => {
     assert.isDefined(oAuthArgs);
   });
 
-  it("Test OAuthArgs with all required params", () => {
+  it("Test OAuthArgs with all required params", function() {
     const oAuthArgs: OAuthArgs = {
       url: "test",
       consumerKey: "test",
@@ -237,8 +237,8 @@ describe("OAuthArgs", () => {
   });
 });
 
-describe("Token", () => {
-  it("Test Token with all required params", () => {
+describe("Token", function() {
+  it("Test Token with all required params", function() {
     const token: Token = {
       accessToken: "test",
       tokenType: "test",

--- a/tests/integration/api-breaks/VersionedLayerClient.test.ts
+++ b/tests/integration/api-breaks/VersionedLayerClient.test.ts
@@ -35,8 +35,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("VersionedLayerClientParams", () => {
-  it("VersionedLayerClientParams with all required params", () => {
+describe("VersionedLayerClientParams", function() {
+  it("VersionedLayerClientParams with all required params", function() {
     const params: VersionedLayerClientParams = {
       catalogHrn: HRN.fromString("hrn:here:data:::example-catalog"),
       layerId: "mocked-layer-id",
@@ -49,7 +49,7 @@ describe("VersionedLayerClientParams", () => {
     assert.isDefined(params);
   });
 
-  it("VersionedLayerClientParams with all required and optional params", () => {
+  it("VersionedLayerClientParams with all required and optional params", function() {
     const params: VersionedLayerClientParams = {
       catalogHrn: HRN.fromString("hrn:here:data:::example-catalog"),
       layerId: "mocked-layer-id",
@@ -64,7 +64,7 @@ describe("VersionedLayerClientParams", () => {
   });
 });
 
-describe("VersionedLayerClient", () => {
+describe("VersionedLayerClient", function() {
   class VersionedLayerClientTest extends VersionedLayerClient {
     constructor(params: VersionedLayerClientParams) {
       super(params);
@@ -94,11 +94,11 @@ describe("VersionedLayerClient", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(function() {
     VersionedLayerClientTest;
   });
 
-  it("Shoud be initialized with arguments", async () => {
+  it("Shoud be initialized with arguments", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -118,7 +118,7 @@ describe("VersionedLayerClient", () => {
     assert.isDefined(layerClient.settings);
   });
 
-  it("Shoud be initialized with VersionedLayerClientParams", async () => {
+  it("Shoud be initialized with VersionedLayerClientParams", async function() {
     const layerClient = new VersionedLayerClient({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -137,7 +137,7 @@ describe("VersionedLayerClient", () => {
     assert.isDefined(layerClient.settings);
   });
 
-  it("getPartitions method with QuadKeyPartitionsRequest", async () => {
+  it("getPartitions method with QuadKeyPartitionsRequest", async function() {
     const layerClient = new VersionedLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -151,7 +151,7 @@ describe("VersionedLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getPartitions method with QuadKeyPartitionsRequest and abort signal", async () => {
+  it("getPartitions method with QuadKeyPartitionsRequest and abort signal", async function() {
     const layerClient = new VersionedLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -170,7 +170,7 @@ describe("VersionedLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getPartitions method with PartitionsRequest", async () => {
+  it("getPartitions method with PartitionsRequest", async function() {
     const layerClient = new VersionedLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -184,7 +184,7 @@ describe("VersionedLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getPartitions method with PartitionsRequest and abort signal", async () => {
+  it("getPartitions method with PartitionsRequest and abort signal", async function() {
     const layerClient = new VersionedLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -203,7 +203,7 @@ describe("VersionedLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getData method method with dataHandle", async () => {
+  it("getData method method with dataHandle", async function() {
     const layerClient = new VersionedLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -220,7 +220,7 @@ describe("VersionedLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getData method method with dataHandle and abort signal", async () => {
+  it("getData method method with dataHandle and abort signal", async function() {
     const layerClient = new VersionedLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",

--- a/tests/integration/api-breaks/VolatileBlob.test.ts
+++ b/tests/integration/api-breaks/VolatileBlob.test.ts
@@ -20,7 +20,6 @@
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
-
 import { VolatileBlobApi } from "@here/olp-sdk-dataservice-api";
 import {
   AuthenticationMessage,
@@ -33,14 +32,14 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("VolatileBlobApi", () => {
-  it("AuthenticationMessage  with all required params", () => {
+describe("VolatileBlobApi", function() {
+  it("AuthenticationMessage  with all required params", function() {
     const params: AuthenticationMessage = {};
 
     assert.isDefined(params);
   });
 
-  it("AuthenticationMessage with all required and optional params", () => {
+  it("AuthenticationMessage with all required and optional params", function() {
     const params: AuthenticationMessage = {
       error: "test",
       errorDescription: "test"
@@ -49,13 +48,13 @@ describe("VolatileBlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("AuthorizationMessage  with all required params", () => {
+  it("AuthorizationMessage  with all required params", function() {
     const params: AuthorizationMessage = {};
 
     assert.isDefined(params);
   });
 
-  it("AuthorizationMessage with all required and optional params", () => {
+  it("AuthorizationMessage with all required and optional params", function() {
     const params: AuthorizationMessage = {
       error: "test",
       errorDescription: "test"
@@ -64,7 +63,7 @@ describe("VolatileBlobApi", () => {
     assert.isDefined(params);
   });
 
-  it("Test checkHandleExists method with all required params", async () => {
+  it("Test checkHandleExists method with all required params", async function() {
     const params = {
       layerId: "test",
       dataHandle: "test"
@@ -78,7 +77,7 @@ describe("VolatileBlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test checkHandleExists method with all required and optional params", async () => {
+  it("Test checkHandleExists method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       dataHandle: "test",
@@ -93,7 +92,7 @@ describe("VolatileBlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteVolatileBlob method with all required params", async () => {
+  it("Test deleteVolatileBlob method with all required params", async function() {
     const params = {
       layerId: "test",
       dataHandle: "test"
@@ -107,7 +106,7 @@ describe("VolatileBlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test deleteVolatileBlob method with all required and optional params", async () => {
+  it("Test deleteVolatileBlob method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       dataHandle: "test",
@@ -122,7 +121,7 @@ describe("VolatileBlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getVolatileBlob method with all required params", async () => {
+  it("Test getVolatileBlob method with all required params", async function() {
     const params = {
       layerId: "test",
       dataHandle: "test"
@@ -136,7 +135,7 @@ describe("VolatileBlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test getVolatileBlob method with all required and optional params", async () => {
+  it("Test getVolatileBlob method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       dataHandle: "test",
@@ -151,7 +150,7 @@ describe("VolatileBlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test putVolatileBlob method with all required params", async () => {
+  it("Test putVolatileBlob method with all required params", async function() {
     const params = {
       layerId: "test",
       dataHandle: "test",
@@ -166,7 +165,7 @@ describe("VolatileBlobApi", () => {
     expect(result).to.be.equal("success");
   });
 
-  it("Test putVolatileBlob method with all required and optional params", async () => {
+  it("Test putVolatileBlob method with all required and optional params", async function() {
     const params = {
       layerId: "test",
       dataHandle: "test",

--- a/tests/integration/api-breaks/VolatileLayerClient.test.ts
+++ b/tests/integration/api-breaks/VolatileLayerClient.test.ts
@@ -35,8 +35,8 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("VolatileLayerClientParams", () => {
-  it("VolatileLayerClientParams with all required params", () => {
+describe("VolatileLayerClientParams", function() {
+  it("VolatileLayerClientParams with all required params", function() {
     const params: VolatileLayerClientParams = {
       catalogHrn: HRN.fromString("hrn:here:data:::example-catalog"),
       layerId: "mocked-layer-id",
@@ -49,7 +49,7 @@ describe("VolatileLayerClientParams", () => {
     assert.isDefined(params);
   });
 
-  it("VolatileLayerClientParams with all required and optional params", () => {
+  it("VolatileLayerClientParams with all required and optional params", function() {
     const params: VolatileLayerClientParams = {
       catalogHrn: HRN.fromString("hrn:here:data:::example-catalog"),
       layerId: "mocked-layer-id",
@@ -63,7 +63,7 @@ describe("VolatileLayerClientParams", () => {
   });
 });
 
-describe("VolatileLayerClient", () => {
+describe("VolatileLayerClient", function() {
   class VolatileLayerClientTest extends VolatileLayerClient {
     constructor(params: VolatileLayerClientParams) {
       super(params);
@@ -93,11 +93,11 @@ describe("VolatileLayerClient", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(function() {
     VolatileLayerClientTest;
   });
 
-  it("Shoud be initialized with arguments", async () => {
+  it("Shoud be initialized with arguments", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -117,7 +117,7 @@ describe("VolatileLayerClient", () => {
     assert.isDefined(layerClient.settings);
   });
 
-  it("Shoud be initialized with VolatileLayerClientParams", async () => {
+  it("Shoud be initialized with VolatileLayerClientParams", async function() {
     const layerClient = new VolatileLayerClient({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -136,7 +136,7 @@ describe("VolatileLayerClient", () => {
     assert.isDefined(layerClient.settings);
   });
 
-  it("getPartitions method with QuadKeyPartitionsRequest", async () => {
+  it("getPartitions method with QuadKeyPartitionsRequest", async function() {
     const layerClient = new VolatileLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -150,7 +150,7 @@ describe("VolatileLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getPartitions method with QuadKeyPartitionsRequest and abort signal", async () => {
+  it("getPartitions method with QuadKeyPartitionsRequest and abort signal", async function() {
     const layerClient = new VolatileLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -169,7 +169,7 @@ describe("VolatileLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getPartitions method with PartitionsRequest", async () => {
+  it("getPartitions method with PartitionsRequest", async function() {
     const layerClient = new VolatileLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -183,7 +183,7 @@ describe("VolatileLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getPartitions method with PartitionsRequest and abort signal", async () => {
+  it("getPartitions method with PartitionsRequest and abort signal", async function() {
     const layerClient = new VolatileLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -202,7 +202,7 @@ describe("VolatileLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getData method method with dataHandle", async () => {
+  it("getData method method with dataHandle", async function() {
     const layerClient = new VolatileLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",
@@ -219,7 +219,7 @@ describe("VolatileLayerClient", () => {
     assert.isDefined(response);
   });
 
-  it("getData method method with dataHandle and abort signal", async () => {
+  it("getData method method with dataHandle and abort signal", async function() {
     const layerClient = new VolatileLayerClientTest({
       catalogHrn: HRN.fromString("hrn:here:data:::test-hrn"),
       layerId: "test-layed-id",

--- a/tests/integration/bundles/umd/olp-sdk-authentication-testCases.ts
+++ b/tests/integration/bundles/umd/olp-sdk-authentication-testCases.ts
@@ -26,13 +26,13 @@ export const OlpSdkAuthenticationTestCases: {
 }[] = [
   {
     it: "UserAuth should be defined",
-    callback: () => {
+    callback: function() {
       assert(UserAuth !== undefined);
     }
   },
   {
     it: "UserAuth should be initialised",
-    callback: () => {
+    callback: function() {
       const userAuth = new UserAuth({
         credentials: {
           accessKeyId: "mocked-id",
@@ -48,7 +48,7 @@ export const OlpSdkAuthenticationTestCases: {
   },
   {
     it: "requestToken should be defined",
-    callback: () => {
+    callback: function() {
       assert(requestToken !== undefined);
     }
   }

--- a/tests/integration/bundles/umd/olp-sdk-dataservice-api-testCases.ts
+++ b/tests/integration/bundles/umd/olp-sdk-dataservice-api-testCases.ts
@@ -18,127 +18,130 @@
  */
 
 import {
-    ArtifactApi,
-    ConfigApi,
-    BlobApi,
-    CoverageApi,
-    IndexApi,
-    LookupApi,
-    MetadataApi,
-    QueryApi,
-    VolatileBlobApi
+  ArtifactApi,
+  ConfigApi,
+  BlobApi,
+  CoverageApi,
+  IndexApi,
+  LookupApi,
+  MetadataApi,
+  QueryApi,
+  VolatileBlobApi
 } from "@here/olp-sdk-dataservice-api";
 
 import assert = require("assert");
 
- export const OlpSdkDataserviceApiTestCases: {it: string, callback: () => void}[] = [
-    {
-        it: "ArtifactApi should be defined",
-        callback: () => {
-            assert(ArtifactApi !== undefined);
-            assert(ArtifactApi.deleteArtifactUsingDELETE !== undefined);
-            assert(ArtifactApi.deleteFileUsingDELETE !== undefined);
-            assert(ArtifactApi.deleteSchemaUsingDELETE !== undefined);
-            assert(ArtifactApi.getArtifactFileUsingGET !== undefined);
-            assert(ArtifactApi.getArtifactUsingGET !== undefined);
-            assert(ArtifactApi.getDocumentUsingGET !== undefined);
-            assert(ArtifactApi.getSchemaUsingGET !== undefined);
-            assert(ArtifactApi.listUsingGET !== undefined);
-            assert(ArtifactApi.putArtifactFileUsingPUT !== undefined);
-            assert(ArtifactApi.registerArtifactUsingPUT !== undefined);
-            assert(ArtifactApi.updateSchemaPermissionUsingPOST !== undefined);
-          }
-    },
-    {
-        it: "ConfigApi should be defined",
-        callback: () => {
-            assert(ConfigApi !== undefined);
-            assert(ConfigApi.catalogExists !== undefined);
-            assert(ConfigApi.createCatalog !== undefined);
-            assert(ConfigApi.deleteCatalog !== undefined);
-            assert(ConfigApi.deleteLayer !== undefined);
-            assert(ConfigApi.getCatalog !== undefined);
-            assert(ConfigApi.getCatalogStatus !== undefined);
-            assert(ConfigApi.getCatalogs !== undefined);
-            assert(ConfigApi.patchCatalog !== undefined);
-            assert(ConfigApi.patchLayer !== undefined);
-            assert(ConfigApi.updateCatalog !== undefined);
-        }
-    },
-    {
-        it: "BlobApi should be defined",
-        callback: () => {
-            assert(BlobApi !== undefined);
-            assert(BlobApi.cancelMultipartUpload !== undefined);
-            assert(BlobApi.checkBlobExists !== undefined);
-            assert(BlobApi.completeMultipartUpload !== undefined);
-            assert(BlobApi.deleteBlob !== undefined);
-            assert(BlobApi.getBlob !== undefined);
-            assert(BlobApi.getMultipartUploadStatus !== undefined);
-            assert(BlobApi.putBlob !== undefined);
-            assert(BlobApi.startMultipartUpload !== undefined);
-            assert(BlobApi.uploadPart !== undefined);
-        }
-    },
-    {
-        it: "CoverageApi should be defined",
-        callback: () => {
-            assert(CoverageApi !== undefined);
-            assert(CoverageApi.getDataCoverageAdminAreas !== undefined);
-            assert(CoverageApi.getDataCoverageSizeMap !== undefined);
-            assert(CoverageApi.getDataCoverageSummary !== undefined);
-            assert(CoverageApi.getDataCoverageTile !== undefined);
-            assert(CoverageApi.getDataCoverageTimeMap !== undefined);
-        }
-    },
-    {
-        it: "IndexApi should be defined",
-        callback: () => {
-            assert(IndexApi !== undefined);
-            assert(IndexApi.insertIndexes !== undefined);
-            assert(IndexApi.performQuery !== undefined);
-            assert(IndexApi.performUpdate !== undefined);
-        }
-    },
-    {
-        it: "LookupApi should be defined",
-        callback: () => {
-            assert(LookupApi !== undefined);
-            assert(LookupApi.platformAPI !== undefined);
-            assert(LookupApi.platformAPIList !== undefined);
-            assert(LookupApi.resourceAPI !== undefined);
-            assert(LookupApi.resourceAPIList !== undefined);
-        }
-    },
-    {
-        it: "MetadataApi should be defined",
-        callback: () => {
-            assert(MetadataApi !== undefined);
-            assert(MetadataApi.getChanges !== undefined);
-            assert(MetadataApi.getLayerVersions !== undefined);
-            assert(MetadataApi.getPartitions !== undefined);
-            assert(MetadataApi.latestVersion !== undefined);
-            assert(MetadataApi.listVersions !== undefined);
-            assert(MetadataApi.minimumVersion !== undefined);
-        }
-    },
-    {
-        it: "QueryApi should be defined",
-        callback: () => {
-            assert(QueryApi.getChangesById !== undefined);
-            assert(QueryApi.getPartitionsById !== undefined);
-            assert(QueryApi.quadTreeIndex !== undefined);
-            assert(QueryApi.quadTreeIndexVolatile !== undefined);
-        }
-    },
-    {
-        it: "VolatileBlobApi should be defined",
-        callback: () => {
-            assert(VolatileBlobApi !== undefined);
-            assert(VolatileBlobApi.checkHandleExists !== undefined);
-            assert(VolatileBlobApi.deleteVolatileBlob !== undefined);
-            assert(VolatileBlobApi.getVolatileBlob !== undefined);
-            assert(VolatileBlobApi.putVolatileBlob !== undefined);
-        }
+export const OlpSdkDataserviceApiTestCases: {
+  it: string;
+  callback: () => void;
+}[] = [
+  {
+    it: "ArtifactApi should be defined",
+    callback: function() {
+      assert(ArtifactApi !== undefined);
+      assert(ArtifactApi.deleteArtifactUsingDELETE !== undefined);
+      assert(ArtifactApi.deleteFileUsingDELETE !== undefined);
+      assert(ArtifactApi.deleteSchemaUsingDELETE !== undefined);
+      assert(ArtifactApi.getArtifactFileUsingGET !== undefined);
+      assert(ArtifactApi.getArtifactUsingGET !== undefined);
+      assert(ArtifactApi.getDocumentUsingGET !== undefined);
+      assert(ArtifactApi.getSchemaUsingGET !== undefined);
+      assert(ArtifactApi.listUsingGET !== undefined);
+      assert(ArtifactApi.putArtifactFileUsingPUT !== undefined);
+      assert(ArtifactApi.registerArtifactUsingPUT !== undefined);
+      assert(ArtifactApi.updateSchemaPermissionUsingPOST !== undefined);
     }
- ];
+  },
+  {
+    it: "ConfigApi should be defined",
+    callback: function() {
+      assert(ConfigApi !== undefined);
+      assert(ConfigApi.catalogExists !== undefined);
+      assert(ConfigApi.createCatalog !== undefined);
+      assert(ConfigApi.deleteCatalog !== undefined);
+      assert(ConfigApi.deleteLayer !== undefined);
+      assert(ConfigApi.getCatalog !== undefined);
+      assert(ConfigApi.getCatalogStatus !== undefined);
+      assert(ConfigApi.getCatalogs !== undefined);
+      assert(ConfigApi.patchCatalog !== undefined);
+      assert(ConfigApi.patchLayer !== undefined);
+      assert(ConfigApi.updateCatalog !== undefined);
+    }
+  },
+  {
+    it: "BlobApi should be defined",
+    callback: function() {
+      assert(BlobApi !== undefined);
+      assert(BlobApi.cancelMultipartUpload !== undefined);
+      assert(BlobApi.checkBlobExists !== undefined);
+      assert(BlobApi.completeMultipartUpload !== undefined);
+      assert(BlobApi.deleteBlob !== undefined);
+      assert(BlobApi.getBlob !== undefined);
+      assert(BlobApi.getMultipartUploadStatus !== undefined);
+      assert(BlobApi.putBlob !== undefined);
+      assert(BlobApi.startMultipartUpload !== undefined);
+      assert(BlobApi.uploadPart !== undefined);
+    }
+  },
+  {
+    it: "CoverageApi should be defined",
+    callback: function() {
+      assert(CoverageApi !== undefined);
+      assert(CoverageApi.getDataCoverageAdminAreas !== undefined);
+      assert(CoverageApi.getDataCoverageSizeMap !== undefined);
+      assert(CoverageApi.getDataCoverageSummary !== undefined);
+      assert(CoverageApi.getDataCoverageTile !== undefined);
+      assert(CoverageApi.getDataCoverageTimeMap !== undefined);
+    }
+  },
+  {
+    it: "IndexApi should be defined",
+    callback: function() {
+      assert(IndexApi !== undefined);
+      assert(IndexApi.insertIndexes !== undefined);
+      assert(IndexApi.performQuery !== undefined);
+      assert(IndexApi.performUpdate !== undefined);
+    }
+  },
+  {
+    it: "LookupApi should be defined",
+    callback: function() {
+      assert(LookupApi !== undefined);
+      assert(LookupApi.platformAPI !== undefined);
+      assert(LookupApi.platformAPIList !== undefined);
+      assert(LookupApi.resourceAPI !== undefined);
+      assert(LookupApi.resourceAPIList !== undefined);
+    }
+  },
+  {
+    it: "MetadataApi should be defined",
+    callback: function() {
+      assert(MetadataApi !== undefined);
+      assert(MetadataApi.getChanges !== undefined);
+      assert(MetadataApi.getLayerVersions !== undefined);
+      assert(MetadataApi.getPartitions !== undefined);
+      assert(MetadataApi.latestVersion !== undefined);
+      assert(MetadataApi.listVersions !== undefined);
+      assert(MetadataApi.minimumVersion !== undefined);
+    }
+  },
+  {
+    it: "QueryApi should be defined",
+    callback: function() {
+      assert(QueryApi.getChangesById !== undefined);
+      assert(QueryApi.getPartitionsById !== undefined);
+      assert(QueryApi.quadTreeIndex !== undefined);
+      assert(QueryApi.quadTreeIndexVolatile !== undefined);
+    }
+  },
+  {
+    it: "VolatileBlobApi should be defined",
+    callback: function() {
+      assert(VolatileBlobApi !== undefined);
+      assert(VolatileBlobApi.checkHandleExists !== undefined);
+      assert(VolatileBlobApi.deleteVolatileBlob !== undefined);
+      assert(VolatileBlobApi.getVolatileBlob !== undefined);
+      assert(VolatileBlobApi.putVolatileBlob !== undefined);
+    }
+  }
+];

--- a/tests/integration/bundles/umd/olp-sdk-dataservice-read-testCases.ts
+++ b/tests/integration/bundles/umd/olp-sdk-dataservice-read-testCases.ts
@@ -21,197 +21,200 @@ import * as Module from "@here/olp-sdk-dataservice-read";
 
 import assert = require("assert");
 
-export const OlpSdkDataserviceReadTestCases: {it: string, callback: () => void}[] = [
-    {
-        it: "OlpClientSettings should be defined",
-        callback: () => {
-            assert(Module.OlpClientSettings !== undefined);
-          }
-    },
-    {
-        it: "RequestFactory should be defined",
-        callback: () => {
-            assert(Module.RequestFactory !== undefined);
-          }
-    },
-    {
-        it: "StatisticsRequest should be defined",
-        callback: () => {
-            assert(Module.StatisticsRequest !== undefined);
-          }
-    },
-    {
-        it: "SummaryRequest should be defined",
-        callback: () => {
-            assert(Module.SummaryRequest !== undefined);
-          }
-    },
-    {
-        it: "VersionedLayerClient should be defined",
-        callback: () => {
-            assert(Module.VersionedLayerClient !== undefined);
-          }
-    },
-    {
-        it: "VolatileLayerClient should be defined",
-        callback: () => {
-            assert(Module.VolatileLayerClient !== undefined);
-          }
-    },
-    {
-        it: "addQuadKeys should be defined",
-        callback: () => {
-            assert(Module.addQuadKeys !== undefined);
-          }
-    },
-    {
-        it: "computeParentKey should be defined",
-        callback: () => {
-            assert(Module.computeParentKey !== undefined);
-          }
-    },
-    {
-        it: "getEnvLookUpUrl should be defined",
-        callback: () => {
-            assert(Module.getEnvLookUpUrl !== undefined);
-          }
-    },
-    {
-        it: "isValid should be defined",
-        callback: () => {
-            assert(Module.isValid !== undefined);
-          }
-    },
-    {
-        it: "mortonCodeFromQuadKey should be defined",
-        callback: () => {
-            assert(Module.mortonCodeFromQuadKey !== undefined);
-          }
-    },
-    {
-        it: "quadKeyFromMortonCode should be defined",
-        callback: () => {
-            assert(Module.quadKeyFromMortonCode !== undefined);
-          }
-    },
-    {
-        it: "validateBillingTag should be defined",
-        callback: () => {
-            assert(Module.validateBillingTag !== undefined);
-          }
-    },
-    {
-        it: "validatePartitionsIdsList should be defined",
-        callback: () => {
-            assert(Module.validatePartitionsIdsList !== undefined);
-          }
-    },
-    {
-        it: "ApiCacheRepository should be defined",
-        callback: () => {
-            assert(Module.ApiCacheRepository !== undefined);
-          }
-    },
-    {
-        it: "ArtifactClient should be defined",
-        callback: () => {
-            assert(Module.ArtifactClient !== undefined);
-          }
-    },
-    {
-        it: "CatalogClient should be defined",
-        callback: () => {
-            assert(Module.CatalogClient !== undefined);
-          }
-    },
-    {
-        it: "CatalogVersionRequest should be defined",
-        callback: () => {
-            assert(Module.CatalogVersionRequest !== undefined);
-          }
-    },
-    {
-        it: "CatalogsRequest should be defined",
-        callback: () => {
-            assert(Module.CatalogsRequest !== undefined);
-          }
-    },
-    {
-        it: "ConfigClient should be defined",
-        callback: () => {
-            assert(Module.ConfigClient !== undefined);
-          }
-    },
-    {
-        it: "CoverageDataType should be defined",
-        callback: () => {
-            assert(Module.CoverageDataType !== undefined);
-          }
-    },
-    {
-        it: "DataRequest should be defined",
-        callback: () => {
-            assert(Module.DataRequest !== undefined);
-          }
-    },
-    {
-        it: "DataStoreDownloadManager should be defined",
-        callback: () => {
-            assert(Module.DataStoreDownloadManager !== undefined);
-          }
-    },
-    {
-        it: "DataStoreRequestBuilder should be defined",
-        callback: () => {
-            assert(Module.DataStoreRequestBuilder !== undefined);
-          }
-    },
-    {
-        it: "HRN should be defined",
-        callback: () => {
-            assert(Module.HRN !== undefined);
-          }
-    },
-    {
-        it: "KeyValueCache should be defined",
-        callback: () => {
-            assert(Module.KeyValueCache !== undefined);
-          }
-    },
-    {
-        it: "LayerVersionsRequest should be defined",
-        callback: () => {
-            assert(Module.LayerVersionsRequest !== undefined);
-          }
-    },
-    {
-        it: "PartitionsRequest should be defined",
-        callback: () => {
-            assert(Module.PartitionsRequest !== undefined);
-          }
-    },
-    {
-        it: "QuadKeyPartitionsRequest should be defined",
-        callback: () => {
-            assert(Module.QuadKeyPartitionsRequest !== undefined);
-          }
-    },
-    {
-        it: "QuadTreeIndexRequest should be defined",
-        callback: () => {
-            assert(Module.QuadTreeIndexRequest !== undefined);
-          }
-    },
-    {
-        it: "QueryClient should be defined",
-        callback: () => {
-            assert(Module.QueryClient !== undefined);
-          }
-    },
-    {
-        it: "SchemaDetailsRequest should be defined",
-        callback: () => {
-            assert(Module.SchemaDetailsRequest !== undefined);
-          }
+export const OlpSdkDataserviceReadTestCases: {
+  it: string;
+  callback: () => void;
+}[] = [
+  {
+    it: "OlpClientSettings should be defined",
+    callback: function() {
+      assert(Module.OlpClientSettings !== undefined);
     }
- ];
+  },
+  {
+    it: "RequestFactory should be defined",
+    callback: function() {
+      assert(Module.RequestFactory !== undefined);
+    }
+  },
+  {
+    it: "StatisticsRequest should be defined",
+    callback: function() {
+      assert(Module.StatisticsRequest !== undefined);
+    }
+  },
+  {
+    it: "SummaryRequest should be defined",
+    callback: function() {
+      assert(Module.SummaryRequest !== undefined);
+    }
+  },
+  {
+    it: "VersionedLayerClient should be defined",
+    callback: function() {
+      assert(Module.VersionedLayerClient !== undefined);
+    }
+  },
+  {
+    it: "VolatileLayerClient should be defined",
+    callback: function() {
+      assert(Module.VolatileLayerClient !== undefined);
+    }
+  },
+  {
+    it: "addQuadKeys should be defined",
+    callback: function() {
+      assert(Module.addQuadKeys !== undefined);
+    }
+  },
+  {
+    it: "computeParentKey should be defined",
+    callback: function() {
+      assert(Module.computeParentKey !== undefined);
+    }
+  },
+  {
+    it: "getEnvLookUpUrl should be defined",
+    callback: function() {
+      assert(Module.getEnvLookUpUrl !== undefined);
+    }
+  },
+  {
+    it: "isValid should be defined",
+    callback: function() {
+      assert(Module.isValid !== undefined);
+    }
+  },
+  {
+    it: "mortonCodeFromQuadKey should be defined",
+    callback: function() {
+      assert(Module.mortonCodeFromQuadKey !== undefined);
+    }
+  },
+  {
+    it: "quadKeyFromMortonCode should be defined",
+    callback: function() {
+      assert(Module.quadKeyFromMortonCode !== undefined);
+    }
+  },
+  {
+    it: "validateBillingTag should be defined",
+    callback: function() {
+      assert(Module.validateBillingTag !== undefined);
+    }
+  },
+  {
+    it: "validatePartitionsIdsList should be defined",
+    callback: function() {
+      assert(Module.validatePartitionsIdsList !== undefined);
+    }
+  },
+  {
+    it: "ApiCacheRepository should be defined",
+    callback: function() {
+      assert(Module.ApiCacheRepository !== undefined);
+    }
+  },
+  {
+    it: "ArtifactClient should be defined",
+    callback: function() {
+      assert(Module.ArtifactClient !== undefined);
+    }
+  },
+  {
+    it: "CatalogClient should be defined",
+    callback: function() {
+      assert(Module.CatalogClient !== undefined);
+    }
+  },
+  {
+    it: "CatalogVersionRequest should be defined",
+    callback: function() {
+      assert(Module.CatalogVersionRequest !== undefined);
+    }
+  },
+  {
+    it: "CatalogsRequest should be defined",
+    callback: function() {
+      assert(Module.CatalogsRequest !== undefined);
+    }
+  },
+  {
+    it: "ConfigClient should be defined",
+    callback: function() {
+      assert(Module.ConfigClient !== undefined);
+    }
+  },
+  {
+    it: "CoverageDataType should be defined",
+    callback: function() {
+      assert(Module.CoverageDataType !== undefined);
+    }
+  },
+  {
+    it: "DataRequest should be defined",
+    callback: function() {
+      assert(Module.DataRequest !== undefined);
+    }
+  },
+  {
+    it: "DataStoreDownloadManager should be defined",
+    callback: function() {
+      assert(Module.DataStoreDownloadManager !== undefined);
+    }
+  },
+  {
+    it: "DataStoreRequestBuilder should be defined",
+    callback: function() {
+      assert(Module.DataStoreRequestBuilder !== undefined);
+    }
+  },
+  {
+    it: "HRN should be defined",
+    callback: function() {
+      assert(Module.HRN !== undefined);
+    }
+  },
+  {
+    it: "KeyValueCache should be defined",
+    callback: function() {
+      assert(Module.KeyValueCache !== undefined);
+    }
+  },
+  {
+    it: "LayerVersionsRequest should be defined",
+    callback: function() {
+      assert(Module.LayerVersionsRequest !== undefined);
+    }
+  },
+  {
+    it: "PartitionsRequest should be defined",
+    callback: function() {
+      assert(Module.PartitionsRequest !== undefined);
+    }
+  },
+  {
+    it: "QuadKeyPartitionsRequest should be defined",
+    callback: function() {
+      assert(Module.QuadKeyPartitionsRequest !== undefined);
+    }
+  },
+  {
+    it: "QuadTreeIndexRequest should be defined",
+    callback: function() {
+      assert(Module.QuadTreeIndexRequest !== undefined);
+    }
+  },
+  {
+    it: "QueryClient should be defined",
+    callback: function() {
+      assert(Module.QueryClient !== undefined);
+    }
+  },
+  {
+    it: "SchemaDetailsRequest should be defined",
+    callback: function() {
+      assert(Module.SchemaDetailsRequest !== undefined);
+    }
+  }
+];

--- a/tests/integration/bundles/umd/olp-sdk-generated.test.ts
+++ b/tests/integration/bundles/umd/olp-sdk-generated.test.ts
@@ -26,8 +26,8 @@ const puppeteer = require("puppeteer");
 let browser: any;
 let page: any;
 
-describe("Test generated olp-edge-datastore-api", () => {
-  before(async () => {
+describe("Test generated olp-edge-datastore-api", function() {
+  before(async function() {
     browser = await puppeteer.launch({
       args: ["no-sandbox", "disable-setuid-sandbox"]
     });
@@ -38,7 +38,7 @@ describe("Test generated olp-edge-datastore-api", () => {
     });
   });
 
-  after(async () => {
+  after(async function() {
     await browser.close();
   });
 
@@ -47,8 +47,8 @@ describe("Test generated olp-edge-datastore-api", () => {
   });
 });
 
-describe("Test generated olp-edge-datastore-read", () => {
-  before(async () => {
+describe("Test generated olp-edge-datastore-read", function() {
+  before(async function() {
     browser = await puppeteer.launch({
       args: ["no-sandbox", "disable-setuid-sandbox"]
     });
@@ -59,7 +59,7 @@ describe("Test generated olp-edge-datastore-read", () => {
     await page.goto("http://127.0.0.1:8080", { waitUntil: "networkidle2" });
   });
 
-  after(async () => {
+  after(async function() {
     await browser.close();
   });
 
@@ -68,8 +68,8 @@ describe("Test generated olp-edge-datastore-read", () => {
   });
 });
 
-describe("Test generated olp-sdk-authentication", () => {
-  before(async () => {
+describe("Test generated olp-sdk-authentication", function() {
+  before(async function() {
     browser = await puppeteer.launch({
       args: ["no-sandbox", "disable-setuid-sandbox"]
     });
@@ -80,7 +80,7 @@ describe("Test generated olp-sdk-authentication", () => {
     await page.goto("http://127.0.0.1:8080", { waitUntil: "networkidle2" });
   });
 
-  after(async () => {
+  after(async function() {
     await browser.close();
   });
 

--- a/tests/integration/bundles/umd/olp-sdk-published.test.ts
+++ b/tests/integration/bundles/umd/olp-sdk-published.test.ts
@@ -26,8 +26,8 @@ const puppeteer = require("puppeteer");
 let browser: any;
 let page: any;
 
-describe("Test published olp-edge-datastore-api", async () => {
-  before(async () => {
+describe("Test published olp-edge-datastore-api", async function() {
+  before(async function() {
     browser = await puppeteer.launch({
       args: ["no-sandbox", "disable-setuid-sandbox"]
     });
@@ -38,7 +38,7 @@ describe("Test published olp-edge-datastore-api", async () => {
     await page.goto("http://127.0.0.1:8080", { waitUntil: "networkidle2" });
   });
 
-  after(async () => {
+  after(async function() {
     await browser.close();
   });
 
@@ -47,8 +47,8 @@ describe("Test published olp-edge-datastore-api", async () => {
   });
 });
 
-describe("Test published olp-edge-datastore-read", () => {
-  before(async () => {
+describe("Test published olp-edge-datastore-read", function() {
+  before(async function() {
     browser = await puppeteer.launch({
       args: ["no-sandbox", "disable-setuid-sandbox"]
     });
@@ -59,7 +59,7 @@ describe("Test published olp-edge-datastore-read", () => {
     await page.goto("http://127.0.0.1:8080", { waitUntil: "networkidle2" });
   });
 
-  after(async () => {
+  after(async function() {
     await browser.close();
   });
 
@@ -68,8 +68,8 @@ describe("Test published olp-edge-datastore-read", () => {
   });
 });
 
-describe("Test published olp-sdk-authentication", () => {
-  before(async () => {
+describe("Test published olp-sdk-authentication", function() {
+  before(async function() {
     browser = await puppeteer.launch({
       args: ["no-sandbox", "disable-setuid-sandbox"]
     });
@@ -80,7 +80,7 @@ describe("Test published olp-sdk-authentication", () => {
     await page.goto("http://127.0.0.1:8080", { waitUntil: "networkidle2" });
   });
 
-  after(async () => {
+  after(async function() {
     await browser.close();
   });
 

--- a/tests/integration/olp-sdk-dataservice-read/ArtifactClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/ArtifactClient.test.ts
@@ -36,22 +36,22 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("ArtifactClient", () => {
+describe("ArtifactClient", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
   let artifactClient: ArtifactClient;
   let settings: OlpClientSettings;
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
@@ -64,12 +64,12 @@ describe("ArtifactClient", () => {
     artifactClient = new ArtifactClient(settings);
   });
 
-  it("Shoud be initialized with settings", async () => {
+  it("Shoud be initialized with settings", async function() {
     assert.isDefined(artifactClient);
     expect(artifactClient).to.be.instanceOf(ArtifactClient);
   });
 
-  it("Should fetch the schema details", async () => {
+  it("Should fetch the schema details", async function() {
     const mockedResponses = new Map();
     const headers = new Headers();
     headers.append("cache-control", "max-age=3600");
@@ -156,7 +156,7 @@ describe("ArtifactClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should getSchemaDetails() handle errors", async () => {
+  it("Should getSchemaDetails() handle errors", async function() {
     const request = new SchemaDetailsRequest().withBillingTag("billing-tag");
 
     const response = await artifactClient
@@ -168,7 +168,7 @@ describe("ArtifactClient", () => {
       });
   });
 
-  it("Should getSchema() handle errors", async () => {
+  it("Should getSchema() handle errors", async function() {
     const request = new SchemaRequest();
 
     const response = await artifactClient.getSchema(request).catch(error => {
@@ -178,7 +178,7 @@ describe("ArtifactClient", () => {
     });
   });
 
-  it("Should fetch file of the schema", async () => {
+  it("Should fetch file of the schema", async function() {
     const mockedResponses = new Map();
     const headers = new Headers();
     headers.append("cache-control", "max-age=3600");
@@ -241,7 +241,7 @@ describe("ArtifactClient", () => {
     expect(fetchStub.callCount).to.be.equal(3);
   });
 
-  it("Should getSchema() handle 400 error", async () => {
+  it("Should getSchema() handle 400 error", async function() {
     const mockedResponses = new Map();
     const headers = new Headers();
     headers.append("cache-control", "max-age=3600");
@@ -291,7 +291,7 @@ describe("ArtifactClient", () => {
     });
   });
 
-  it("Should user-agent be added to the each request", async () => {
+  it("Should user-agent be added to the each request", async function() {
     const mockedResponses = new Map();
     const headers = new Headers();
     headers.append("cache-control", "max-age=3600");

--- a/tests/integration/olp-sdk-dataservice-read/CatalogClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/CatalogClient.test.ts
@@ -36,7 +36,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("CatalogClient", () => {
+describe("CatalogClient", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
@@ -45,15 +45,15 @@ describe("CatalogClient", () => {
   const headers = new Headers();
   headers.append("cache-control", "max-age=3600");
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
@@ -69,12 +69,12 @@ describe("CatalogClient", () => {
     );
   });
 
-  it("Shoud be initialized with settings", async () => {
+  it("Shoud be initialized with settings", async function() {
     assert.isDefined(catalogClient);
     expect(catalogClient).to.be.instanceOf(CatalogClient);
   });
 
-  it("Should fetch the information about about specific catalog versions", async () => {
+  it("Should fetch the information about about specific catalog versions", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.
@@ -174,7 +174,7 @@ describe("CatalogClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should fetch the information about all catalog versions", async () => {
+  it("Should fetch the information about all catalog versions", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.
@@ -310,7 +310,7 @@ describe("CatalogClient", () => {
     expect(fetchStub.callCount).to.be.equal(3);
   });
 
-  it("Should fetch the configuration of all catalogs", async () => {
+  it("Should fetch the configuration of all catalogs", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.
@@ -375,7 +375,7 @@ describe("CatalogClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should fetch the configuration of all catalogs 2", async () => {
+  it("Should fetch the configuration of all catalogs 2", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.
@@ -438,7 +438,7 @@ describe("CatalogClient", () => {
     });
   });
 
-  it("Should read the full catalog configuration for the requested catalog", async () => {
+  it("Should read the full catalog configuration for the requested catalog", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.
@@ -518,7 +518,7 @@ describe("CatalogClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should getEarliestVersion() return version", async () => {
+  it("Should getEarliestVersion() return version", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.
@@ -557,7 +557,7 @@ describe("CatalogClient", () => {
     expect(version).to.be.equal(42);
   });
 
-  it("Should getLayerVersions() with latest version return layer version", async () => {
+  it("Should getLayerVersions() with latest version return layer version", async function() {
     const mockedResponses = new Map();
     const mockedResponse = {
       version: 42,
@@ -600,7 +600,7 @@ describe("CatalogClient", () => {
     expect(versions.length).to.be.equal(mockedResponse.layerVersions.length);
   });
 
-  it("Should getLayerVersions() without latest version return layer version", async () => {
+  it("Should getLayerVersions() without latest version return layer version", async function() {
     const mockedResponses = new Map();
     const mockedResponse = {
       version: 42,

--- a/tests/integration/olp-sdk-dataservice-read/ConfigClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/ConfigClient.test.ts
@@ -37,22 +37,22 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("configClient", () => {
+describe("configClient", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
   let configClient: ConfigClient;
   let settings: OlpClientSettings;
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
@@ -65,12 +65,12 @@ describe("configClient", () => {
     configClient = new ConfigClient(settings);
   });
 
-  it("Shoud be initialized with settings", async () => {
+  it("Shoud be initialized with settings", async function() {
     assert.isDefined(configClient);
     expect(configClient).to.be.instanceOf(ConfigClient);
   });
 
-  it("Should fetch the list of catalogs to which you have access", async () => {
+  it("Should fetch the list of catalogs to which you have access", async function() {
     const mockedResponses = new Map();
 
     const mockedCatalogsHRN: ConfigApi.CatalogsListResult = {
@@ -119,7 +119,7 @@ describe("configClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should fetch the list of catalogs to which you have access filtered by hrn", async () => {
+  it("Should fetch the list of catalogs to which you have access filtered by hrn", async function() {
     const mockedResponses = new Map();
 
     const mockedCatalogsFilteredByHRN: ConfigApi.CatalogsListResult = {
@@ -161,7 +161,7 @@ describe("configClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should user-agent be added to the each request", async () => {
+  it("Should user-agent be added to the each request", async function() {
     const mockedResponses = new Map();
 
     const mockedCatalogsHRN: ConfigApi.CatalogsListResult = {

--- a/tests/integration/olp-sdk-dataservice-read/Handling-versions.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/Handling-versions.test.ts
@@ -37,7 +37,7 @@ import { FetchMock } from "../FetchMock";
 chai.use(sinonChai);
 const expect = chai.expect;
 
-describe("Handling versions in the requests classes and clients", () => {
+describe("Handling versions in the requests classes and clients", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
@@ -46,15 +46,15 @@ describe("Handling versions in the requests classes and clients", () => {
   const headers = new Headers();
   headers.append("cache-control", "max-age=3600");
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
@@ -66,7 +66,7 @@ describe("Handling versions in the requests classes and clients", () => {
     });
   });
 
-  it("Should use version 0 for getPartitions with PartitionsRequest.withVersion(0).withPartitionIds(['23605706']);", async () => {
+  it("Should use version 0 for getPartitions with PartitionsRequest.withVersion(0).withPartitionIds(['23605706']);", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -132,7 +132,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use version 0 for getPartitions with QuadKeyPartitionsRequest.withVersion(0).withQuadKey(quadKeyFromMortonCode(23605706));", async () => {
+  it("Should use version 0 for getPartitions with QuadKeyPartitionsRequest.withVersion(0).withQuadKey(quadKeyFromMortonCode(23605706));", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -209,7 +209,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use version 0 for getData with DataRequest.withVersion(0).withQuadKey(quadKeyFromMortonCode(23605706));", async () => {
+  it("Should use version 0 for getData with DataRequest.withVersion(0).withQuadKey(quadKeyFromMortonCode(23605706));", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -301,7 +301,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use version 0 for getData with DataRequest.withVersion(0).withPartitionId('23605706');", async () => {
+  it("Should use version 0 for getData with DataRequest.withVersion(0).withPartitionId('23605706');", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -380,7 +380,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use locked version 142 for getPartitions with PartitionsRequest.withPartitionIds(['23605706']);", async () => {
+  it("Should use locked version 142 for getPartitions with PartitionsRequest.withPartitionIds(['23605706']);", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -444,7 +444,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use locked version 142 for getPartitions with QuadKeyPartitionsRequest.withQuadKey(quadKeyFromMortonCode(23605706));", async () => {
+  it("Should use locked version 142 for getPartitions with QuadKeyPartitionsRequest.withQuadKey(quadKeyFromMortonCode(23605706));", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -521,7 +521,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use locked version 142 for getData with DataRequest.withQuadKey(quadKeyFromMortonCode(23605706));", async () => {
+  it("Should use locked version 142 for getData with DataRequest.withQuadKey(quadKeyFromMortonCode(23605706));", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -611,7 +611,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use locked version 142 for getData with DataRequest.withPartitionId('23605706');", async () => {
+  it("Should use locked version 142 for getData with DataRequest.withPartitionId('23605706');", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -690,7 +690,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use latest version for getPartitions with PartitionsRequest.withPartitionIds(['23605706']) and lock it;", async () => {
+  it("Should use latest version for getPartitions with PartitionsRequest.withPartitionIds(['23605706']) and lock it;", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -770,7 +770,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use latest version for getPartitions with QuadKeyPartitionsRequest.withQuadKey(quadKeyFromMortonCode(23605706)) and lock it;", async () => {
+  it("Should use latest version for getPartitions with QuadKeyPartitionsRequest.withQuadKey(quadKeyFromMortonCode(23605706)) and lock it;", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -863,7 +863,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use latest version for getData with DataRequest.withQuadKey(quadKeyFromMortonCode(23605706)) and lock it;", async () => {
+  it("Should use latest version for getData with DataRequest.withQuadKey(quadKeyFromMortonCode(23605706)) and lock it;", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -969,7 +969,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use latest version for getData with DataRequest.withPartitionId('23605706') and lock it;", async () => {
+  it("Should use latest version for getData with DataRequest.withPartitionId('23605706') and lock it;", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -1064,7 +1064,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use version 0 for getLayerVersions with LayerVersionsRequest.withVersion(0);", async () => {
+  it("Should use version 0 for getLayerVersions with LayerVersionsRequest.withVersion(0);", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(
@@ -1125,7 +1125,7 @@ describe("Handling versions in the requests classes and clients", () => {
     );
   });
 
-  it("Should use version 0 for getVersions with CatalogVersionRequest.withEndVersion(0);", async () => {
+  it("Should use version 0 for getVersions with CatalogVersionRequest.withEndVersion(0);", async function() {
     const mockedResponses = new Map();
 
     mockedResponses.set(

--- a/tests/integration/olp-sdk-dataservice-read/IndexLayerClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/IndexLayerClient.test.ts
@@ -35,7 +35,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("IndexLayerClient", () => {
+describe("IndexLayerClient", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
@@ -43,21 +43,21 @@ describe("IndexLayerClient", () => {
   const testHRN = HRN.fromString("hrn:here:data:::test-hrn");
   const testLayerId = "test-layed-id";
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
   });
 
-  it("Should be initialized with settings", async () => {
+  it("Should be initialized with settings", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -71,7 +71,7 @@ describe("IndexLayerClient", () => {
     expect(indexClient).to.be.instanceOf(IndexLayerClient);
   });
 
-  it("Should initialization error be handled", () => {
+  it("Should initialization error be handled", function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -87,7 +87,7 @@ describe("IndexLayerClient", () => {
     }
   });
 
-  it("Should be fetched partitions all metadata", async () => {
+  it("Should be fetched partitions all metadata", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Index service.
@@ -181,7 +181,7 @@ describe("IndexLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should getPartitions() method handle errors", async () => {
+  it("Should getPartitions() method handle errors", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -197,7 +197,7 @@ describe("IndexLayerClient", () => {
     });
   });
 
-  it("Should getData() method handle errors", async () => {
+  it("Should getData() method handle errors", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -212,7 +212,7 @@ describe("IndexLayerClient", () => {
     });
   });
 
-  it("Should be fetched data with dataHandle", async () => {
+  it("Should be fetched data with dataHandle", async function() {
     const mockedResponses = new Map();
     const mockedData = Buffer.alloc(42);
     const mockedModel = {
@@ -269,7 +269,7 @@ describe("IndexLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should be initialized with IndexLayerClientParams", async () => {
+  it("Should be initialized with IndexLayerClientParams", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -287,7 +287,7 @@ describe("IndexLayerClient", () => {
     assert.equal(indexLayerClient["hrn"], "hrn:here:data:::test-hrn");
   });
 
-  it("Should user-agent be added to the each request", async () => {
+  it("Should user-agent be added to the each request", async function() {
     const mockedResponses = new Map();
     const mockedData = Buffer.alloc(42);
     const mockedModel = {

--- a/tests/integration/olp-sdk-dataservice-read/Metadata-api.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/Metadata-api.test.ts
@@ -31,21 +31,21 @@ import { FetchMock } from "../FetchMock";
 chai.use(sinonChai);
 const expect = chai.expect;
 
-describe("CatalogClient", () => {
+describe("CatalogClient", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
   let settings: OlpClientSettings;
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
@@ -57,7 +57,7 @@ describe("CatalogClient", () => {
     });
   });
 
-  it("Should be passsed parameter Range to the headers of the metadata request", async () => {
+  it("Should be passsed parameter Range to the headers of the metadata request", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.

--- a/tests/integration/olp-sdk-dataservice-read/StatisticsClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/StatisticsClient.test.ts
@@ -36,7 +36,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("StatisticsClient", () => {
+describe("StatisticsClient", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
@@ -47,15 +47,15 @@ describe("StatisticsClient", () => {
   const mockedHRN = HRN.fromString("hrn:here:data:::mocked-hrn");
   const mockedLayerId = "mocked-layed-id";
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
@@ -68,12 +68,12 @@ describe("StatisticsClient", () => {
     statisticsClient = new StatisticsClient(settings);
   });
 
-  it("Shoud be initialized with settings", async () => {
+  it("Shoud be initialized with settings", async function() {
     assert.isDefined(statisticsClient);
     expect(statisticsClient).to.be.instanceOf(StatisticsClient);
   });
 
-  it("Should fetch the summary info from statistics service", async () => {
+  it("Should fetch the summary info from statistics service", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api
@@ -146,7 +146,7 @@ describe("StatisticsClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should method getSummary return error if catalogHRN is not provided", async () => {
+  it("Should method getSummary return error if catalogHRN is not provided", async function() {
     const mockedErrorResponse = "No catalogHrn provided";
 
     const summaryRequest = new SummaryRequest().withLayerId(mockedLayerId);
@@ -159,7 +159,7 @@ describe("StatisticsClient", () => {
       });
   });
 
-  it("Should method getSummary return error if layerId is not provided", async () => {
+  it("Should method getSummary return error if layerId is not provided", async function() {
     const mockedErrorResponse = "No layerId provided";
 
     const summaryRequest = new SummaryRequest().withCatalogHrn(mockedHRN);
@@ -172,7 +172,7 @@ describe("StatisticsClient", () => {
       });
   });
 
-  it("Should method getStatistics return timemap statistics data", async () => {
+  it("Should method getStatistics return timemap statistics data", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api
@@ -219,7 +219,7 @@ describe("StatisticsClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should method getStatistics return sizemap statistics data", async () => {
+  it("Should method getStatistics return sizemap statistics data", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api
@@ -266,7 +266,7 @@ describe("StatisticsClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should method getStatistics return bitmap statistics data", async () => {
+  it("Should method getStatistics return bitmap statistics data", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api
@@ -313,7 +313,7 @@ describe("StatisticsClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should user-agent be added to the each request", async () => {
+  it("Should user-agent be added to the each request", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api

--- a/tests/integration/olp-sdk-dataservice-read/StreamLayerClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/StreamLayerClient.test.ts
@@ -38,7 +38,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("StreamLayerClient", () => {
+describe("StreamLayerClient", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
@@ -46,21 +46,21 @@ describe("StreamLayerClient", () => {
   const testHRN = HRN.fromString("hrn:here:data:::test-hrn");
   const testLayerId = "test-layed-id";
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
   });
 
-  it("Shoud be initialized with StreamLayerClientParams", async () => {
+  it("Shoud be initialized with StreamLayerClientParams", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -78,7 +78,7 @@ describe("StreamLayerClient", () => {
     assert.equal(streamLayerClient["layerId"], "test-layed-id");
   });
 
-  it("Shoud getData() fetch data with dataHandle", async () => {
+  it("Shoud getData() fetch data with dataHandle", async function() {
     const mockedResponses = new Map();
     const mockedData = Buffer.alloc(42);
 
@@ -142,7 +142,7 @@ describe("StreamLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Should getData() method handle error", async () => {
+  it("Should getData() method handle error", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -158,7 +158,7 @@ describe("StreamLayerClient", () => {
     });
   });
 
-  it("Should subscribe() method return data", async () => {
+  it("Should subscribe() method return data", async function() {
     const mockedResponses = new Map();
     const headers = new Headers();
     headers.append("X-Correlation-Id", "9141392.f96875c-9422-4df4-b5ff");
@@ -216,7 +216,7 @@ describe("StreamLayerClient", () => {
     expect(result).equal("-9141392.f96875c-9422-4df4-b5ff-41a4f459");
   });
 
-  it("Should poll() method get messages from stream layer", async () => {
+  it("Should poll() method get messages from stream layer", async function() {
     const mockedResponses = new Map();
     const headers = new Headers();
     const commitOffsetsResponse = new Response("Ok");
@@ -318,7 +318,7 @@ describe("StreamLayerClient", () => {
     expect(messages[0].metaData.dataSize).to.be.equal(100500);
   });
 
-  it("Should poll() method handle errors", async () => {
+  it("Should poll() method handle errors", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -344,7 +344,7 @@ describe("StreamLayerClient", () => {
     });
   });
 
-  it("Shoult unsubscribe() method cancel subscription", async () => {
+  it("Shoult unsubscribe() method cancel subscription", async function() {
     const mockedResponses = new Map();
     const headers = new Headers();
     headers.append("X-Correlation-Id", "9141392.f96875c-9422-4df4-b5ff");
@@ -410,7 +410,7 @@ describe("StreamLayerClient", () => {
     expect(unsubscription.status).to.be.equal(200);
   });
 
-  it("Should unsubscribe() method handle errors", async () => {
+  it("Should unsubscribe() method handle errors", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -436,7 +436,7 @@ describe("StreamLayerClient", () => {
     });
   });
 
-  it("Should seek() method handle errors", async () => {
+  it("Should seek() method handle errors", async function() {
     const mockedResponses = new Map();
     const headers = new Headers();
     headers.append("X-Correlation-Id", "9141392.f96875c-9422-4df4-b5ff");

--- a/tests/integration/olp-sdk-dataservice-read/VersionedLayerClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/VersionedLayerClient.test.ts
@@ -39,7 +39,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("VersionedLayerClient", () => {
+describe("VersionedLayerClient", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
@@ -49,21 +49,21 @@ describe("VersionedLayerClient", () => {
   const headers = new Headers();
   headers.append("cache-control", "max-age=3600");
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
   });
 
-  it("Shoud be initialized with settings", async () => {
+  it("Shoud be initialized with settings", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -77,7 +77,7 @@ describe("VersionedLayerClient", () => {
     expect(layerClient).to.be.instanceOf(VersionedLayerClient);
   });
 
-  it("Shoud be initialization error be handled", async () => {
+  it("Shoud be initialization error be handled", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -93,7 +93,7 @@ describe("VersionedLayerClient", () => {
     }
   });
 
-  it("Shoud be initialized with VersionedLayerClientParams with version", async () => {
+  it("Shoud be initialized with VersionedLayerClientParams with version", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -112,7 +112,7 @@ describe("VersionedLayerClient", () => {
     expect(layerClientWithVersion).to.be.instanceOf(VersionedLayerClient);
   });
 
-  it("Shoud be initialised with VersionedLayerClientParams without version", async () => {
+  it("Shoud be initialised with VersionedLayerClientParams without version", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -130,7 +130,7 @@ describe("VersionedLayerClient", () => {
     expect(layerClientWithoutVersion).to.be.instanceOf(VersionedLayerClient);
   });
 
-  it("Shoud be fetched partitions metadata for specific IDs", async () => {
+  it("Shoud be fetched partitions metadata for specific IDs", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Query API.
@@ -243,7 +243,7 @@ describe("VersionedLayerClient", () => {
     }
   });
 
-  it("Shoud be fetched partitions all metadata", async () => {
+  it("Shoud be fetched partitions all metadata", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.
@@ -365,7 +365,7 @@ describe("VersionedLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(3);
   });
 
-  it("Shoud be fetched data with dataHandle", async () => {
+  it("Shoud be fetched data with dataHandle", async function() {
     const mockedResponses = new Map();
     const mockedDataHandle = "1b2ca68f-d4a0-4379-8120-cd025640510c";
     const mockedData = Buffer.alloc(42);
@@ -426,7 +426,7 @@ describe("VersionedLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(2); // 1 - lookup, 1 - blob
   });
 
-  it("Shoud be fetched data with PartitionId", async () => {
+  it("Shoud be fetched data with PartitionId", async function() {
     const mockedResponses = new Map();
     const mockedPartitionId = "0000042";
     const mockedData = Buffer.alloc(42);
@@ -521,7 +521,7 @@ describe("VersionedLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(4);
   });
 
-  it("Shoud be fetched data with PartitionId and version", async () => {
+  it("Shoud be fetched data with PartitionId and version", async function() {
     const mockedResponses = new Map();
     const mockedPartitionId = "0000042";
     const mockedData = Buffer.alloc(42);
@@ -603,7 +603,7 @@ describe("VersionedLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(3); // 1 - lookup, 1 - query, 1 - blob
   });
 
-  it("Shoud be fetched data with QuadKey", async () => {
+  it("Shoud be fetched data with QuadKey", async function() {
     const mockedResponses = new Map();
     const mockedQuadKey = quadKeyFromMortonCode("23618403");
     const mockedData = Buffer.alloc(42);
@@ -700,7 +700,7 @@ describe("VersionedLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(4);
   });
 
-  it("Shoud be fetched data with QuadKey and Version", async () => {
+  it("Shoud be fetched data with QuadKey and Version", async function() {
     const mockedResponses = new Map();
     const mockedQuadKey = quadKeyFromMortonCode("23618403");
     const mockedData = Buffer.alloc(42);
@@ -784,7 +784,7 @@ describe("VersionedLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(3); // 1 - lookup, 1 - query, 1 - blob
   });
 
-  it("Shoud read partitions metadata by QuadKey for specific VersionLayer", async () => {
+  it("Shoud read partitions metadata by QuadKey for specific VersionLayer", async function() {
     const mockedResponses = new Map();
 
     const billingTag = "billingTag";
@@ -918,7 +918,7 @@ describe("VersionedLayerClient", () => {
     }
   });
 
-  it("Shoud read partitions with additionalFields parameter from PartitionsRequest", async () => {
+  it("Shoud read partitions with additionalFields parameter from PartitionsRequest", async function() {
     const mockedResponses = new Map();
 
     const mockedPartitions = {
@@ -1009,7 +1009,7 @@ describe("VersionedLayerClient", () => {
     );
   });
 
-  it("Shoud read partitions with additionalFields parameter from QuadKeyPartitionsRequest", async () => {
+  it("Shoud read partitions with additionalFields parameter from QuadKeyPartitionsRequest", async function() {
     const mockedResponses = new Map();
 
     const mockedQuadKey = {
@@ -1113,7 +1113,7 @@ describe("VersionedLayerClient", () => {
     assert.isDefined(partitions);
   });
 
-  it("Should user-agent be added to the each request", async () => {
+  it("Should user-agent be added to the each request", async function() {
     const mockedResponses = new Map();
     const mockedDataHandle = "1b2ca68f-d4a0-4379-8120-cd025640510c";
     const mockedData = Buffer.alloc(42);

--- a/tests/integration/olp-sdk-dataservice-read/VolatileLayerClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/VolatileLayerClient.test.ts
@@ -38,7 +38,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("VolatileLayerClient", () => {
+describe("VolatileLayerClient", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
@@ -48,21 +48,21 @@ describe("VolatileLayerClient", () => {
   const headers = new Headers();
   headers.append("cache-control", "max-age=3600");
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
   });
 
-  it("Shoud be initialized with settings", async () => {
+  it("Shoud be initialized with settings", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -76,7 +76,7 @@ describe("VolatileLayerClient", () => {
     expect(layerClient).to.be.instanceOf(VolatileLayerClient);
   });
 
-  it("Shoud be initialization error be handled", async () => {
+  it("Shoud be initialization error be handled", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -92,7 +92,7 @@ describe("VolatileLayerClient", () => {
     }
   });
 
-  it("Shoud be fetched partitions metadata for specific IDs", async () => {
+  it("Shoud be fetched partitions metadata for specific IDs", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Query API.
@@ -189,7 +189,7 @@ describe("VolatileLayerClient", () => {
     }
   });
 
-  it("Shoud be fetched data with PartitionId", async () => {
+  it("Shoud be fetched data with PartitionId", async function() {
     const mockedResponses = new Map();
     const mockedPartitionId = "0000042";
     const mockedData = Buffer.alloc(42);
@@ -271,7 +271,7 @@ describe("VolatileLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(3);
   });
 
-  it("Shoud be fetched partitions all metadata", async () => {
+  it("Shoud be fetched partitions all metadata", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.
@@ -370,7 +370,7 @@ describe("VolatileLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Shoud read data with dataHandle", async () => {
+  it("Shoud read data with dataHandle", async function() {
     const mockedResponses = new Map();
     const mockedDataHandle = "1b2ca68f-d4a0-4379-8120-cd025640510c";
     const mockedData = Buffer.alloc(42);
@@ -422,7 +422,7 @@ describe("VolatileLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(2);
   });
 
-  it("Shoud be fetched data with QuadKey", async () => {
+  it("Shoud be fetched data with QuadKey", async function() {
     const mockedResponses = new Map();
     const mockedQuadKey = quadKeyFromMortonCode("23618403");
     const mockedData = Buffer.alloc(42);
@@ -522,7 +522,7 @@ describe("VolatileLayerClient", () => {
     expect(fetchStub.callCount).to.be.equal(4);
   });
 
-  it("Shoud read partitions metadata by QuadKey for specific VolatileLayer", async () => {
+  it("Shoud read partitions metadata by QuadKey for specific VolatileLayer", async function() {
     const mockedResponses = new Map();
 
     const billingTag = "billingTag";
@@ -648,7 +648,7 @@ describe("VolatileLayerClient", () => {
     }
   });
 
-  it("Shoud read partitions with additionalFields parameter from PartitionsRequest", async () => {
+  it("Shoud read partitions with additionalFields parameter from PartitionsRequest", async function() {
     const mockedResponses = new Map();
 
     const mockedPartitions = {
@@ -732,7 +732,7 @@ describe("VolatileLayerClient", () => {
     );
   });
 
-  it("Shoud read partitions with additionalFields parameter from QuadKeyPartitionsRequest", async () => {
+  it("Shoud read partitions with additionalFields parameter from QuadKeyPartitionsRequest", async function() {
     const mockedResponses = new Map();
 
     const mockedQuadKey = {
@@ -836,7 +836,7 @@ describe("VolatileLayerClient", () => {
     assert.isDefined(partitions);
   });
 
-  it("Shoud be initialized with VolatileLayerClientParams", async () => {
+  it("Shoud be initialized with VolatileLayerClientParams", async function() {
     const settings = new OlpClientSettings({
       environment: "here",
       getToken: () => Promise.resolve("test-token-string")
@@ -856,7 +856,7 @@ describe("VolatileLayerClient", () => {
     assert.equal(volatileLayerClient["hrn"], "hrn:here:data:::test-hrn");
   });
 
-  it("Should user-agent be added to the each request", async () => {
+  it("Should user-agent be added to the each request", async function() {
     const mockedResponses = new Map();
     const mockedDataHandle = "1b2ca68f-d4a0-4379-8120-cd025640510c";
     const mockedData = Buffer.alloc(42);

--- a/tests/integration/olp-sdk-dataservice-write/VersionedLayer.test.ts
+++ b/tests/integration/olp-sdk-dataservice-write/VersionedLayer.test.ts
@@ -30,7 +30,7 @@ chai.use(sinonChai);
 const assert = chai.assert;
 const expect = chai.expect;
 
-describe("Versioned Layer Client for write", () => {
+describe("Versioned Layer Client for write", function() {
   let fetchMock: FetchMock;
   let sandbox: sinon.SinonSandbox;
   let fetchStub: sinon.SinonStub;
@@ -45,15 +45,15 @@ describe("Versioned Layer Client for write", () => {
   const headers = new Headers();
   headers.append("cache-control", "max-age=3600");
 
-  before(() => {
+  before(function() {
     sandbox = sinon.createSandbox();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  beforeEach(() => {
+  beforeEach(function() {
     fetchMock = new FetchMock();
     fetchStub = sandbox.stub(global as any, "fetch");
     fetchStub.callsFake(fetchMock.fetch());
@@ -64,7 +64,7 @@ describe("Versioned Layer Client for write", () => {
     });
   });
 
-  it("Should initialize", () => {
+  it("Should initialize", function() {
     const client = new VersionedLayerClient({
       catalogHrn,
       settings
@@ -74,7 +74,7 @@ describe("Versioned Layer Client for write", () => {
     expect(client).be.instanceOf(VersionedLayerClient);
   });
 
-  xit("Should fetch the latest version of catalog", async () => {
+  xit("Should fetch the latest version of catalog", async function() {
     const mockedResponses = new Map();
 
     // Set the response from lookup api with the info about Metadata service.


### PR DESCRIPTION
Mocha discourages using arrow functions,
see https://mochajs.org/#arrow-functions

Passing arrow functions (aka “lambdas”) to Mocha is discouraged.
Lambdas lexically bind this and cannot access the Mocha context.

If you do not need to use Mocha’s context, lambdas should work.
Be aware that using lambdas will be more painful
to refactor if the need eventually arises!

Resolves: OLPEDGE-2011

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>