### PR TITLE
Add several minor CodeCov settings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,6 @@ regression_generate_report_job:
   tags:
   - docker-prod
   image: python:3.6
-  when: always
   before_script:
     - pip install junit2html
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     name: "PSV Linux Build & Test"
     script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh && env
     after_success:
-        - bash <(curl -s https://codecov.io/bash)
+        - bash <(curl -s https://codecov.io/bash) || sleep 10 && bash <(curl -s https://codecov.io/bash)
   - language: minimal
     name: "PSV Commit checker script"
     script: $WORKSPACE/scripts/misc/commit_checker.sh

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,11 @@
 coverage:
-  range: 60..100
+  range: 80..100
   round: up
   precision: 4
-  parsers:
-    javascript:
-      enable_partials: no
+  notify:
+    wait_for_ci: false
+  ci:
+    - "travis.org"
   status:
     project:
       authentication:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,9 @@ coverage:
   range: 60..100
   round: up
   precision: 4
+  parsers:
+    javascript:
+      enable_partials: no
   status:
     project:
       authentication:


### PR DESCRIPTION
Also fix minor typo in generate report job option on Gitlab.
Improve codecov load by adding retry logic.
Needed for more precise calculation of Code Coverage.
As local calculation is different from CodeCov.

Relates-To: OLPEDGE-1912

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>
