### PR TITLE
Change bash uploader to codecov,update ignored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
   - language: node_js
     name: "PSV Linux Build & Test"
     script: $WORKSPACE/scripts/linux/psv/travis_build_test_psv.sh && env
-    after_success:
-        - bash <(curl -s https://codecov.io/bash) || sleep 10 && bash <(curl -s https://codecov.io/bash)
   - language: minimal
     name: "PSV Commit checker script"
     script: $WORKSPACE/scripts/misc/commit_checker.sh

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,10 +30,11 @@ coverage:
         threshold: 1
 ignore:
   - ./@here/olp-sdk-authentication/test
-  - ./@here/olp-sdk-dataservice-read/test
-  - ./@here/olp-sdk-fetch/test
+  - ./@here/olp-sdk-core/test
   - ./@here/olp-sdk-dataservice-api/test
+  - ./@here/olp-sdk-dataservice-read/test
   - ./@here/olp-sdk-dataservice-write/test
-  - tests
-  - scripts
+  - ./@here/olp-sdk-fetch/test
   - docs
+  - scripts
+  - tests

--- a/scripts/linux/psv/travis_build_test_psv.sh
+++ b/scripts/linux/psv/travis_build_test_psv.sh
@@ -40,9 +40,6 @@ npm run lint
 # Run tests
 npm run test
 
-# Generate and upload codecov
-npm run codecov
-
 # Integration tests
 npm run integration-test
 
@@ -51,3 +48,6 @@ npm run functional-test
 
 # Test the generated bundles
 npm run http-server-testing-bundles & npm run test-generated-bundles
+
+# Generate and upload codecov
+( npm run codecov && ./node_modules/.bin/codecov ) || ( echo "CodeCov exited with non-zero, please investigate!" && exit 1 )


### PR DESCRIPTION
Add core test dir to ignore list.
Try to fix CodeCov precision issues by changing approach of
loading data to CodeCov. Add exit 1 when CodeCov failed.
Sorted list of ignored paths.

Relate-To: OLPEDGE-1912

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>