### PR TITLE
Add more responses to the retry logic.

### DIFF
--- a/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
+++ b/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
@@ -94,7 +94,7 @@ export class DataStoreDownloadManager implements DownloadManager {
         try {
             const response = await fetchFunction(url, init);
             if (
-                response.status !== STATUS_CODES.SERVICE_UNAVAIBLE ||
+                !this.requestShouldRetryOnError(response.status) ||
                 retryCount >= maxRetries
             ) {
                 if (
@@ -128,6 +128,14 @@ export class DataStoreDownloadManager implements DownloadManager {
                 url,
                 init
             )
+        );
+    }
+
+    private static requestShouldRetryOnError(code: number): boolean {
+        return (
+            (code >= STATUS_CODES.INTERNAL_SERVER_ERROR &&
+                code <= STATUS_CODES.NETWORK_CONNECT_TIMEOUT) ||
+            code === STATUS_CODES.TO_MANY_REQUESTS
         );
     }
 

--- a/@here/olp-sdk-core/lib/utils/index.ts
+++ b/@here/olp-sdk-core/lib/utils/index.ts
@@ -25,7 +25,10 @@ export enum STATUS_CODES {
     CREATED = 201,
     NO_CONTENT = 204,
     NOT_FOUND = 404,
-    SERVICE_UNAVAIBLE = 503
+    TO_MANY_REQUESTS = 429,
+    INTERNAL_SERVER_ERROR = 500,
+    SERVICE_UNAVAIBLE = 503,
+    NETWORK_CONNECT_TIMEOUT = 599
 }
 
 export * from "./DataStoreDownloadManager";

--- a/@here/olp-sdk-dataservice-read/lib/client/ArtifactClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/ArtifactClient.ts
@@ -90,6 +90,7 @@ export class ArtifactClient {
             artifactHrn: variant.url
         }).catch(async error => {
             const messages: { [key: number]: string } = {
+                400: "Bad request",
                 401: "You are not authorized to view the schema",
                 403: "Accessing the schema is forbidden",
                 404: "The schema was not found",

--- a/tests/integration/olp-sdk-dataservice-read/ArtifactClient.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/ArtifactClient.test.ts
@@ -271,7 +271,7 @@ describe("ArtifactClient", function() {
     // Set the response from Metadata service with the versions info from the catalog.
     mockedResponses.set(
       `https://artifact.data.api.platform.here.com/artifact/v1/artifact/hrn:here:artifact:::com.here.schema.fake:100500-v2`,
-      new HttpError(500, "Internal server error")
+      { status: 400, statusText: "Bad request" }
     );
 
     // Setup the fetch to use mocked responses.
@@ -286,7 +286,7 @@ describe("ArtifactClient", function() {
 
     const response = await artifactClient.getSchema(request).catch(error => {
       expect(error.message).equal(
-        "Artifact Service error: HTTP 500: Internal server error"
+        "Artifact Service error: HTTP 400: Bad request"
       );
     });
   });


### PR DESCRIPTION
This CR adds 429 and all 5xx responses to the retry logic.
Fixes wrong test and handling 400 error in ArtifactClient and
changes the initial timeout from 500ms to 200ms.

Resolves: OLPEDGE-2210

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>