### PR TITLE
Update publishing config.

### DIFF
--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -22,6 +22,8 @@
 
 echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
 
+yarn
+
 while [[ $# -gt 0 ]]; do
     key="$1"
     case "$key" in
@@ -31,7 +33,7 @@ while [[ $# -gt 0 ]]; do
         ;;
         -core)
         # olp-sdk-core publish
-        cd @here/olp-sdk-core && npm install && npm publish && cd -
+        cd @here/olp-sdk-core && npm install && npm publish --access=public && cd -
         ;;
         -api)
         # olp-sdk-dataservice-api publish
@@ -47,7 +49,7 @@ while [[ $# -gt 0 ]]; do
         ;;
         -write)
         # olp-sdk-dataservice-write publish
-        cd @here/olp-sdk-dataservice-write && npm install && npm publish && cd -
+        cd @here/olp-sdk-dataservice-write && npm install && npm publish --access=public && cd -
         ;;
     esac
     # Shift after checking all the cases to get the next option


### PR DESCRIPTION
The default access setting is private for the
first time you publish a scoped package, so we're
changing that.

Relates-To: OLPEDGE-2116

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>