### PR TITLE
Add dataservice-api as a dep. for core

### DIFF
--- a/@here/olp-sdk-authentication/package.json
+++ b/@here/olp-sdk-authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-authentication",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Wrapper around the HERE Authentication and Authorization REST API obtaining short-lived access tokens that are used to authenticate requests to HERE services.",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,9 +49,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "1.0.0",
+    "@here/olp-sdk-core": "^1.0.0",
     "@types/properties-reader": "^0.0.1",
-    "@here/olp-sdk-fetch": "1.5.0",
+    "@here/olp-sdk-fetch": "^1.5.0",
     "properties-reader": "^0.3.1"
   },
   "devDependencies": {

--- a/@here/olp-sdk-core/package.json
+++ b/@here/olp-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Core features of the HERE Data Platform",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,7 +49,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-fetch": "1.5.0"
+    "@here/olp-sdk-fetch": "^1.5.0",
+    "@here/olp-sdk-dataservice-api": "^1.5.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/@here/olp-sdk-dataservice-read/package.json
+++ b/@here/olp-sdk-dataservice-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-read",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Wrapper around a subset of the HERE Open Location Platform Data REST API related to reading data from OLP catalogs",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,9 +49,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "1.0.0",
-    "@here/olp-sdk-dataservice-api": "1.5.0",
-    "@here/olp-sdk-fetch": "1.5.0"
+    "@here/olp-sdk-core": "^1.0.0",
+    "@here/olp-sdk-dataservice-api": "^1.5.0",
+    "@here/olp-sdk-fetch": "^1.5.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/@here/olp-sdk-dataservice-write/README.md
+++ b/@here/olp-sdk-dataservice-write/README.md
@@ -73,11 +73,10 @@ The maximum number of partitions you can upload and publish in one request is 1,
 
 **To publish data to the versioned layer:**
 
-1. Add the `@here/olp-sdk-dataservice-api` and `@here/olp-sdk-dataservice-write` packages to your dependencies.
+1. Add the `@here/olp-sdk-dataservice-write` package to your dependencies.
 
     ```
-    "@here/olp-sdk-dataservice-api": "1.5.0",
-    "@here/olp-sdk-dataservice-write": "1.0.0"
+    "@here/olp-sdk-dataservice-write": "^1.0.0"
     ```
 
 2. Import classes from the `olp-sdk-dataservice-write` module.

--- a/@here/olp-sdk-dataservice-write/package.json
+++ b/@here/olp-sdk-dataservice-write/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-write",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Wrapper around a subset of the HERE Open Location Platform Data REST API related to writing data to OLP catalogs",
   "main": "index.js",
   "browser": "index.web.js",
@@ -50,8 +50,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "1.0.0",
-    "@here/olp-sdk-fetch": "1.5.0"
+    "@here/olp-sdk-core": "^1.0.0",
+    "@here/olp-sdk-fetch": "^1.5.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v1.5.1 (19/08/2020)
+
+**olp-sdk-core**
+
+- Added `@here/olp-sdk-dataservice-api` as a dependency.
+
+**olp-sdk-authentication**
+
+- Updated `olp-sdk-core` to version ^1.0.0.
+
+**olp-sdk-dataservice-read**
+
+- Updated `olp-sdk-core` to version ^1.0.0.
+
+**olp-sdk-dataservice-write**
+
+- Updated `olp-sdk-core` to version ^1.0.0.
+
+
 ## v1.5.0 (18/08/2020)
 
 **olp-sdk-core**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-ts",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "HERE OLP SDK for TypeScript",
   "author": {
     "name": "HERE Europe B.V.",

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -22,8 +22,6 @@
 
 echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
 
-yarn
-
 while [[ $# -gt 0 ]]; do
     key="$1"
     case "$key" in
@@ -33,7 +31,7 @@ while [[ $# -gt 0 ]]; do
         ;;
         -core)
         # olp-sdk-core publish
-        cd @here/olp-sdk-core && npm install && npm publish --access=public && cd -
+        cd @here/olp-sdk-core && npm install && npm publish && cd -
         ;;
         -api)
         # olp-sdk-dataservice-api publish
@@ -49,7 +47,7 @@ while [[ $# -gt 0 ]]; do
         ;;
         -write)
         # olp-sdk-dataservice-write publish
-        cd @here/olp-sdk-dataservice-write && npm install && npm publish --access=public && cd -
+        cd @here/olp-sdk-dataservice-write && npm install && npm publish && cd -
         ;;
     esac
     # Shift after checking all the cases to get the next option


### PR DESCRIPTION
Adding @here/olp-sdk-dataservice-api to the dependencies of the
@here/olp-sdk-core and update configs and README.

Bump versions.
Update CHANGLOG.md.
Update scripts.

Resolves: OLPEDGE-2253

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>