### PR TITLE
Start http server before testing bundles

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,7 @@ release_verify_job:
   - yarn
   - yarn bootstrap
   - npm run build
+  - npm run http-server-testing-bundles
   - npm run test-published-bundles
   when: manual
   only:


### PR DESCRIPTION
Before testing published bundles, the local server should be started.

Resolve: OLPEDGE-2251

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>