### PR TITLE
Start http server before testing bundles

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,11 +96,11 @@ release_verify_job:
   - yarn
   - yarn bootstrap
   - npm run build
-  - npm run http-server-testing-bundles
-  - npm run test-published-bundles
+  - npm run http-server-testing-bundles & npm run test-published-bundles
   when: manual
   only:
     - master
+    - branches
 
 weekly_security_test_job:
   stage: test

--- a/tests/integration/bundles/umd/olp-sdk-published.test.ts
+++ b/tests/integration/bundles/umd/olp-sdk-published.test.ts
@@ -35,7 +35,6 @@ describe("Test published olp-edge-datastore-api", async function() {
     await page.addScriptTag({
       url: "https://unpkg.com/@here/olp-sdk-dataservice-api/bundle.umd.min.js"
     });
-    await page.goto("http://127.0.0.1:8080", { waitUntil: "networkidle2" });
   });
 
   after(async function() {


### PR DESCRIPTION
Before testing published bundles, the local server should be started.

Resolves: OLPEDGE-2251

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>