### PR TITLE
Review the public API doc for the write module

### DIFF
--- a/@here/olp-sdk-dataservice-write/lib/client/CancelBatchRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/CancelBatchRequest.ts
@@ -18,16 +18,18 @@
  */
 
 /**
- * @brief CancelBatchRequest is used to cancel a versioned batch operation.
+ * Cancels a versioned batch operation.
  */
 export class CancelBatchRequest {
     private publicationId?: string;
     private billingTag?: string;
 
     /**
-     * @brief set the ID of the publication to cancel.
-     * @param id the ID of the publication to cancel.
-     * @returns reference to this object
+     * Sets the ID of the publication that you want to cancel.
+     * 
+     * @param id The ID of the publication.
+     * 
+     * @returns A reference to this object.
      */
     public withPublicationId(id: string): CancelBatchRequest {
         this.publicationId = id;
@@ -35,10 +37,12 @@ export class CancelBatchRequest {
     }
 
     /**
-     * @param billing_tag An optional free-form tag which is used for grouping
-     * billing records together. If supplied, it must be between 4 - 16
-     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     * @note Optional.
+     * Sets the billing tag.
+     * 
+     * @param tag The free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
+     * 
+     * @returns A reference to this object.
      */
     public withBillingTag(tag: string): CancelBatchRequest {
         this.billingTag = tag;
@@ -46,15 +50,18 @@ export class CancelBatchRequest {
     }
 
     /**
-     * @brief get the ID of the publication to cancel.
-     * @returns The ID of the publication to cancel, required.
+     * Gets the ID of the publication that you want to cancel.
+     * 
+     * @returns The ID of the publication.
      */
     public getPublicationId(): string | undefined {
         return this.publicationId;
     }
 
     /**
-     * @return Billing Tag previously set or undefined.
+     * Gets the billing tag (if it was set).
+     * 
+     * @return The billing tag or `undefined` if it was not.
      */
     public getBillingTag(): string | undefined {
         return this.billingTag;

--- a/@here/olp-sdk-dataservice-write/lib/client/CheckDataExistsRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/CheckDataExistsRequest.ts
@@ -18,7 +18,7 @@
  */
 
 /**
- * @brief Check data existence request structure holding all necessary information.
+ * Checks if a structure of a data existence request holds all necessary information.
  */
 export class CheckDataExistsRequest {
     private layerId?: string;
@@ -26,11 +26,11 @@ export class CheckDataExistsRequest {
     private billingTag?: string;
 
     /**
-     * @brief set the ID of the layer to check if data exist.
-     * @param layerId the ID of the layer.
-     * @note Required.
+     * Sets the ID of the layer to check if data exist.
+     * 
+     * @param layerId The ID of the layer.
      *
-     * @returns reference to this object
+     * @returns A reference to this object.
      */
     public withLayerId(layerId: string): CheckDataExistsRequest {
         this.layerId = layerId;
@@ -38,21 +38,21 @@ export class CheckDataExistsRequest {
     }
 
     /**
-     * @brief get the ID of the layer.
-     * @returns The ID of the layer to check.
+     * Gets the ID of the layer that you want to check.
+     * 
+     * @returns The layer ID.
      */
     public getLayerId(): string | undefined {
         return this.layerId;
     }
 
     /**
-     * @brief set the DataHandle to check if data exist.
-     * @param dataHandele string. Can be any unique number or a hash of the content or metadata.
+     * Sets the data handle to check if data exist.
+     * 
+     * @param dataHandele The data handle. Can be any unique number or a hash of the content or metadata.
      * Data handles must be unique within the layer across all versions.
      *
-     * @note Required.
-     *
-     * @returns reference to this object
+     * @returns A reference to this object.
      */
     public withDataHandle(dataHandle: string): CheckDataExistsRequest {
         this.dataHandle = dataHandle;
@@ -60,19 +60,21 @@ export class CheckDataExistsRequest {
     }
 
     /**
-     * @brief get the DataHandle.previously set or undefined
-     * @returns The datahandle.
+     * Gets the data handle (if it was set).
+     * 
+     * @returns The data handle or `undefined` if it was not set.
      */
     public getDataHandle(): string | undefined {
         return this.dataHandle;
     }
 
     /**
-     * @param billing_tag An optional free-form tag which is used for grouping
-     * billing records together. If supplied, it must be between 4 - 16
-     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     *
-     * @note Optional.
+     * Sets the billing tag.
+     * 
+     * @param tag he free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
+     * 
+     * @returns A reference to this object.
      */
     public withBillingTag(tag: string): CheckDataExistsRequest {
         this.billingTag = tag;
@@ -80,7 +82,9 @@ export class CheckDataExistsRequest {
     }
 
     /**
-     * @return Billing Tag previously set or undefined.
+     * Gets the billing tag (if it was set).
+     * 
+     * @return The billing tag or `undefined` if it was not set.
      */
     public getBillingTag(): string | undefined {
         return this.billingTag;

--- a/@here/olp-sdk-dataservice-write/lib/client/CompleteBatchRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/CompleteBatchRequest.ts
@@ -18,17 +18,18 @@
  */
 
 /**
- * @brief CompleteBatchRequest is used to complete a publication.
+ * Completes a publication.
  */
 export class CompleteBatchRequest {
     private publicationId?: string;
     private billingTag?: string;
 
     /**
-     * @brief set the ID of the publication to submit.
-     * @param id the ID of the publication to submit.
-     * @note Required.
-     * @returns reference to this object
+     * Sets the ID of the publication that you want to submit.
+     * 
+     * @param id The ID of the publication to submit.
+     * 
+     * @returns A reference to this object.
      */
     public withPublicationId(id: string): CompleteBatchRequest {
         this.publicationId = id;
@@ -36,10 +37,12 @@ export class CompleteBatchRequest {
     }
 
     /**
-     * @param billing_tag An optional free-form tag which is used for grouping
-     * billing records together. If supplied, it must be between 4 - 16
-     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     * @note Optional.
+     * Sets the billing tag.
+     * 
+     * @param tag The free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
+     * 
+     * @returns A reference to this object.
      */
     public withBillingTag(tag: string): CompleteBatchRequest {
         this.billingTag = tag;
@@ -47,15 +50,18 @@ export class CompleteBatchRequest {
     }
 
     /**
-     * @brief get the ID of the publication to cancel.
-     * @returns The ID of the publication to cancel, required.
+     * Gets the ID of the publication that you want to submit.
+     * 
+     * @returns The publication ID.
      */
     public getPublicationId(): string | undefined {
         return this.publicationId;
     }
 
     /**
-     * @return Billing Tag previously set or undefined.
+     * Gets the billing tag (if it was set).
+     * 
+     * @return The billing tag or `undefined` if it was not set.
      */
     public getBillingTag(): string | undefined {
         return this.billingTag;

--- a/@here/olp-sdk-dataservice-write/lib/client/GetBatchRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/GetBatchRequest.ts
@@ -18,16 +18,18 @@
  */
 
 /**
- * @brief GetBatchRequest is used to retrieve the publication details.
+ * Gets publication details.
  */
 export class GetBatchRequest {
     private publicationId?: string;
     private billingTag?: string;
 
     /**
-     * @brief set the ID of the publication to retrieve the publication details.
-     * @param id the ID of the publication to retrieve the publication details.
-     * @returns reference to this object
+     * Sets the ID of the publication to retrieve the publication details.
+     * 
+     * @param id The ID of the publication details of which you want to retrieve.
+     * 
+     * @returns A reference to this object.
      */
     public withPublicationId(id: string): GetBatchRequest {
         this.publicationId = id;
@@ -35,10 +37,12 @@ export class GetBatchRequest {
     }
 
     /**
-     * @param billing_tag An optional free-form tag which is used for grouping
-     * billing records together. If supplied, it must be between 4 - 16
-     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     * @note Optional.
+     * Sets the billing tag.
+     * 
+     * @param tag The free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
+     * 
+     * @returns A reference to this object.
      */
     public withBillingTag(tag: string): GetBatchRequest {
         this.billingTag = tag;
@@ -46,15 +50,18 @@ export class GetBatchRequest {
     }
 
     /**
-     * @brief get the ID of the publication to retrieve the publication details.
-     * @returns The ID of the publication to retrieve the publication details, required.
+     * Gets the ID of the publication to retrieve the publication details.
+     * 
+     * @returns The ID of the publication details of which you want to retrieve.
      */
     public getPublicationId(): string | undefined {
         return this.publicationId;
     }
 
     /**
-     * @return Billing Tag previously set or undefined.
+     * Gets the billing tag (if it was set).
+     * 
+     * @return The billing tag or `undefined` if it was not set.
      */
     public getBillingTag(): string | undefined {
         return this.billingTag;

--- a/@here/olp-sdk-dataservice-write/lib/client/PublishSinglePartitionRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/PublishSinglePartitionRequest.ts
@@ -20,7 +20,7 @@
 import { PublishPartition } from "@here/olp-sdk-dataservice-api/lib/publish-api-v2";
 
 /**
- * @brief PublishSinglePartitionRequest is used to upload single partition.
+ * @brief Uploads a single partition.
  */
 export class PublishSinglePartitionRequest {
     private publicationId?: string;
@@ -32,10 +32,11 @@ export class PublishSinglePartitionRequest {
     private contentEncoding?: string;
 
     /**
-     * @brief set the ID of the publication to upload.
-     * @param id the ID of the publication to upload.
-     * @note Required.
-     * @returns reference to this object
+     * Sets the ID of the publication that you want to upload.
+     * 
+     * @param id The ID of the publication that you want to upload.
+     * 
+     * @returns A reference to this object.
      */
     public withPublicationId(id: string): PublishSinglePartitionRequest {
         this.publicationId = id;
@@ -43,18 +44,20 @@ export class PublishSinglePartitionRequest {
     }
 
     /**
-     * @brief get the ID of the publication to upload.
-     * @returns The ID of the publication to upload, required.
+     * Gets the ID of the publication that you want to upload.
+     * 
+     * @returns The ID of the publication that you want to upload.
      */
     public getPublicationId(): string | undefined {
         return this.publicationId;
     }
 
     /**
-     * @brief set the ID of the layer.
-     * @param id the ID of the layer.
-     * @note Required.
-     * @returns reference to this object
+     * Sets the ID of the layer.
+     * 
+     * @param id The layer ID.
+     * 
+     * @returns A reference to this object.
      */
     public withLayerId(id: string): PublishSinglePartitionRequest {
         this.layerId = id;
@@ -62,18 +65,22 @@ export class PublishSinglePartitionRequest {
     }
 
     /**
-     * @brief get the ID of the layer.
-     * @returns The ID of the layer, required.
+     * Gets the ID of the layer.
+     * 
+     * @returns The ID of the layer.
      */
     public getLayerId(): string | undefined {
         return this.layerId;
     }
 
     /**
-     * Sets the data for uploading.
-     * @param data The data to be uploaded to the Blob API.
-     * @note Required.
-     * @returns reference to this object
+     * Uses embedded data in the `PublishPartition` or `uploadBlob()` API.
+     * 
+     * @param data The content published directly to the metadata and encoded in Base64.
+     * The size of the content is limited.
+     * @note It will be used in stream layers and present only if the message size is less than or equal to 1 MB.
+     * 
+     * @returns A reference to this object.
      */
     public withData(data: ArrayBuffer | Buffer): PublishSinglePartitionRequest {
         this.data = data;
@@ -81,16 +88,22 @@ export class PublishSinglePartitionRequest {
     }
 
     /**
-     * @return data previously set or undefined.
+     * Gets the data (if it was set).
+     * 
+     * @return The data or `undefined` if it was not set.
      */
     public getData(): ArrayBuffer | Buffer | undefined {
         return this.data;
     }
 
     /**
-     * @brief set the content encoding of the data to upload. Can be gzip or identity.
-     * @param contentEncoding the content encoding of the data to upload.
-     * @returns reference to this object
+     * Set the content encoding of the data to upload.
+     * 
+     * Can be `gzip` or identity.
+     * 
+     * @param contentEncoding The content encoding of the data to upload.
+     * 
+     * @returns A reference to this object
      */
     public withContentEncoding(
         contentEncoding: string
@@ -100,7 +113,8 @@ export class PublishSinglePartitionRequest {
     }
 
     /**
-     * @brief get the content encoding of the data to upload.
+     * @brief Gets the content encoding of the data to upload.
+     * 
      * @returns The content encoding of the data to upload.
      */
     public getContentEncoding(): string | undefined {
@@ -108,10 +122,11 @@ export class PublishSinglePartitionRequest {
     }
 
     /**
-     * @brief set the content type of the data to upload.
-     * @param contentType the content type of the data to upload.
-     * @note Required.
-     * @returns reference to this object
+     * @brief Sets the content type of the data to upload.
+     * 
+     * @param contentType The content type of the data to upload.
+     * 
+     * @returns A reference to this object
      */
     public withContentType(contentType: string): PublishSinglePartitionRequest {
         this.contentType = contentType;
@@ -119,7 +134,7 @@ export class PublishSinglePartitionRequest {
     }
 
     /**
-     * @brief get the content type of the data to upload.
+     * @brief Gets the content type of the data to upload.
      * @returns The content type of the data to upload.
      */
     public getContentType(): string | undefined {
@@ -127,10 +142,11 @@ export class PublishSinglePartitionRequest {
     }
 
     /**
-     * @brief set the metadata of the partition to upload.
-     * @param metaData  The metadata to be published for the blob data.
-     * @note Required.
-     * @returns reference to this object
+     * Sets the metadata of the partition that you want to publish.
+     * 
+     * @param metaData The metadata for the blob data that you want to publish.
+     * 
+     * @returns A reference to this object.
      */
     public withMetaData(
         metaData: PublishPartition
@@ -140,19 +156,21 @@ export class PublishSinglePartitionRequest {
     }
 
     /**
-     * @brief get the the metadata of the partition.
-     * @returns The the metadata of the partition.
+     * Gets the metadata of the partition.
+     * 
+     * @returns The metadata of the partition.
      */
     public getMetadata(): PublishPartition | undefined {
         return this.metaData;
     }
 
     /**
-     * @brief set the billing tag.
-     * @param billing_tag An optional free-form tag which is used for grouping
-     * billing records together. If supplied, it must be between 4 - 16
-     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     * @note Optional.
+     * Sets the billing tag.
+     * 
+     * @param tag The free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
+     * 
+     * @returns A reference to this object.
      */
     public withBillingTag(tag: string): PublishSinglePartitionRequest {
         this.billingTag = tag;
@@ -160,7 +178,9 @@ export class PublishSinglePartitionRequest {
     }
 
     /**
-     * @return Billing Tag previously set or undefined.
+     * Gets the billing tag (if it was set).
+     * 
+     * @return The billing tag or `undefined` if it was not set.
      */
     public getBillingTag(): string | undefined {
         return this.billingTag;

--- a/@here/olp-sdk-dataservice-write/lib/client/StartBatchRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/StartBatchRequest.ts
@@ -20,7 +20,7 @@
 import { PublishApi } from "@here/olp-sdk-dataservice-api";
 
 /**
- * @brief StartBatchRequest is used to start a versioned batch operation.
+ * Starts a batch operation for a versioned layer.
  */
 export class StartBatchRequest {
     private layers?: string[];
@@ -28,9 +28,11 @@ export class StartBatchRequest {
     private billingTag?: string;
 
     /**
-     * @brief set the layers used in this batch operation
-     * @param layers layer id's to be used
-     * @returns reference to this object
+     * Sets the layers to use in this batch operation.
+     * 
+     * @param layers The IDs of the layers to use in this batch operation.
+     * 
+     * @returns A reference to this object.
      */
     public withLayers(layers: string[]): StartBatchRequest {
         this.layers = layers;
@@ -38,9 +40,11 @@ export class StartBatchRequest {
     }
 
     /**
-     * @brief set the version dependencies used in this batch operation
-     * @param versionDependencies array of VersionDependencies
-     * @returns reference to this object
+     * Sets the version dependencies used in this batch operation.
+     * 
+     * @param versionDependencies The array of version dependencies.
+     * 
+     * @returns A reference to this object.
      */
     public withVersionDependencies(
         versionDependencies: PublishApi.VersionDependency[]
@@ -50,10 +54,12 @@ export class StartBatchRequest {
     }
 
     /**
-     * @param billing_tag An optional free-form tag which is used for grouping
-     * billing records together. If supplied, it must be between 4 - 16
-     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     * @note Optional.
+     * Sets the billing tag.
+     * 
+     * @param tag The free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
+     * 
+     * @returns A reference to this object.
      */
     public withBillingTag(tag: string): StartBatchRequest {
         this.billingTag = tag;
@@ -61,16 +67,18 @@ export class StartBatchRequest {
     }
 
     /**
-     * @brief get the layers used in this batch operation
-     * @returns array of layers ids or undefined
+     * Gets the layers used in this batch operation.
+     * 
+     * @returns The array of layer IDs or `undefined`.
      */
     public getLayers(): string[] | undefined {
         return this.layers;
     }
 
     /**
-     * @brief gets the VersionDependencies of this batch operation
-     * @returns the array of VersionDependencies or undefined
+     * Gets the version dependencies of this batch operation.
+     * 
+     * @returns The array of the version dependencies or `undefined`.
      */
     public getVersionDependencies():
         | PublishApi.VersionDependency[]
@@ -79,7 +87,9 @@ export class StartBatchRequest {
     }
 
     /**
-     * @return Billing Tag previously set or undefined.
+     * Gets the billing tag (if it was set).
+     * 
+     * @return The billing tag or `undefined` if it was not set.
      */
     public getBillingTag(): string | undefined {
         return this.billingTag;

--- a/@here/olp-sdk-dataservice-write/lib/client/UploadBlobRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/UploadBlobRequest.ts
@@ -18,7 +18,7 @@
  */
 
 /**
- * @brief UploadBlobRequest is used to upload the data to the DS.
+ * Uupload data to the DS.
  */
 export class UploadBlobRequest {
     private dataHandle?: string;
@@ -29,10 +29,13 @@ export class UploadBlobRequest {
     private contentEncoding?: string;
 
     /**
-     * @brief set the content encoding of the data to upload. Can be gzip or identity.
-     * @param contentEncoding the content encoding of the data to upload.
-     * @note Optional.
-     * @returns reference to this object
+     * Sets the content encoding of the data to upload.
+     * 
+     * Can be `gzip` or identity.
+     * 
+     * @param contentEncoding The content encoding of the data to upload.
+     * 
+     * @returns A reference to this object
      */
     public withContentEncoding(contentEncoding: string): UploadBlobRequest {
         this.contentEncoding = contentEncoding;
@@ -40,7 +43,8 @@ export class UploadBlobRequest {
     }
 
     /**
-     * @brief get the content encoding of the data to upload.
+     * Gets the content encoding of the data to upload.
+     * 
      * @returns The content encoding of the data to upload.
      */
     public getContentEncoding(): string | undefined {
@@ -48,10 +52,11 @@ export class UploadBlobRequest {
     }
 
     /**
-     * @brief set the content type of the data to upload.
+     * Sets the content type of the data to upload.
+     * 
      * @param contentType the content type of the data to upload.
-     * @note Required.
-     * @returns reference to this object
+     * 
+     * @returns A reference to this object
      */
     public withContentType(contentType: string): UploadBlobRequest {
         this.contentType = contentType;
@@ -59,7 +64,8 @@ export class UploadBlobRequest {
     }
 
     /**
-     * @brief get the content type of the data to upload.
+     * Gets the content type of the data to upload.
+     * 
      * @returns The content type of the data to upload.
      */
     public getContentType(): string | undefined {
@@ -67,10 +73,11 @@ export class UploadBlobRequest {
     }
 
     /**
-     * @brief set the datahandle of the data to upload.
+     * Sets the data handle of the data to upload.
+     * 
      * @param id the datahandle of the data to upload.
-     * @note Required.
-     * @returns reference to this object
+     * 
+     * @returns A reference to this object
      */
     public withDataHandle(dataHandle: string): UploadBlobRequest {
         this.dataHandle = dataHandle;
@@ -78,18 +85,20 @@ export class UploadBlobRequest {
     }
 
     /**
-     * @brief get the datahandle of the data to upload.
-     * @returns The datahandle of the data to upload, required.
+     * Gets the data handle of the data to upload.
+     * 
+     * @returns The data handle of the data to upload.
      */
     public getDataHandle(): string | undefined {
         return this.dataHandle;
     }
 
     /**
-     * @brief set the ID of the layer.
+     * Sets the ID of the layer.
+     * 
      * @param id the ID of the layer.
-     * @note Required.
-     * @returns reference to this object
+     * 
+     * @returns A reference to this object
      */
     public withLayerId(id: string): UploadBlobRequest {
         this.layerId = id;
@@ -97,18 +106,20 @@ export class UploadBlobRequest {
     }
 
     /**
-     * @brief get the ID of the layer.
-     * @returns The ID of the layer, required.
+     * Gets the ID of the layer.
+     * 
+     * @returns The ID of the layer.
      */
     public getLayerId(): string | undefined {
         return this.layerId;
     }
 
     /**
-     * @brief set the data to upload.
+     * Sets the data to upload.
+     * 
      * @param data The buffer of the data to upload.
-     * @note Required.
-     * @returns reference to this object
+     * 
+     * @returns A reference to this object
      */
     public withData(data: ArrayBuffer | Buffer): UploadBlobRequest {
         this.data = data;
@@ -116,18 +127,21 @@ export class UploadBlobRequest {
     }
 
     /**
-     * @return data previously set or undefined.
+     * Gets the data (if it was set).
+     * 
+     * @return The data previously set or undefined.
      */
     public getData(): ArrayBuffer | Buffer | undefined {
         return this.data;
     }
 
     /**
-     * @brief set the billing tag.
-     * @param billing_tag An optional free-form tag which is used for grouping
-     * billing records together. If supplied, it must be between 4 - 16
-     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     * @note Optional.
+     * Sets the billing tag.
+     * 
+     * @param tag The free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
+     * 
+     * @returns A reference to this object.
      */
     public withBillingTag(tag: string): UploadBlobRequest {
         this.billingTag = tag;
@@ -135,7 +149,9 @@ export class UploadBlobRequest {
     }
 
     /**
-     * @return Billing Tag previously set or undefined.
+     * Gets the billing tag (if it was set).
+     * 
+     * @return The billing tag or `undefined` if it was not set.
      */
     public getBillingTag(): string | undefined {
         return this.billingTag;

--- a/@here/olp-sdk-dataservice-write/lib/client/UploadBlobResult.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/UploadBlobResult.ts
@@ -21,10 +21,10 @@ export class UploadBlobResult {
     private dataHandle?: string;
 
     /**
-     * @brief set the datahandle of the uploaded data.
-     * @param id the datahandle.
-     * @note required.
-     * @returns reference to this object
+     * @brief Sets the data handle of the uploaded data.
+     * @param id The data handle.
+     * 
+     * @returns A reference to this object
      */
     public withDataHandle(dataHandle: string): UploadBlobResult {
         this.dataHandle = dataHandle;
@@ -32,8 +32,9 @@ export class UploadBlobResult {
     }
 
     /**
-     * @brief get the datahandle of the uploaded data.
-     * @returns The datahandle of the data to upload.
+     * @brief Gets the data handle of the uploaded data.
+     * 
+     * @returns The data handle of the uploaded data.
      */
     public getDataHandle(): string | undefined {
         return this.dataHandle;

--- a/@here/olp-sdk-dataservice-write/lib/client/UploadPartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/UploadPartitionsRequest.ts
@@ -20,7 +20,7 @@
 import { PublishPartitions } from "@here/olp-sdk-dataservice-api/lib/publish-api-v2";
 
 /**
- * @brief UploadPartitionsRequest is used to upload multiple partitions at once.
+ * @brief Uploads multiple partitions at once.
  */
 export class UploadPartitionsRequest {
     private publicationId?: string;
@@ -29,10 +29,11 @@ export class UploadPartitionsRequest {
     private publishPartitions?: PublishPartitions;
 
     /**
-     * @brief set the ID of the publication to upload.
-     * @param id the ID of the publication to upload.
-     * @note Required.
-     * @returns reference to this object
+     * Sets the ID of the publication to upload.
+     * 
+     * @param id The ID of the publication to upload.
+     * 
+     * @returns A reference to this object.
      */
     public withPublicationId(id: string): UploadPartitionsRequest {
         this.publicationId = id;
@@ -40,18 +41,20 @@ export class UploadPartitionsRequest {
     }
 
     /**
-     * @brief get the ID of the publication to upload.
-     * @returns The ID of the publication to upload, required.
+     * Gets the ID of the publication to upload.
+     * 
+     * @returns The ID of the publication to upload.
      */
     public getPublicationId(): string | undefined {
         return this.publicationId;
     }
 
     /**
-     * @brief set the ID of the layer.
-     * @param id the ID of the layer.
-     * @note Required.
-     * @returns reference to this object
+     * Sets the ID of the layer.
+     * 
+     * @param id The ID of the layer.
+     * 
+     * @returns A reference to this object.
      */
     public withLayerId(id: string): UploadPartitionsRequest {
         this.layerId = id;
@@ -59,18 +62,20 @@ export class UploadPartitionsRequest {
     }
 
     /**
-     * @brief get the ID of the layer.
-     * @returns The ID of the layer, required.
+     * Gets the ID of the layer.
+     * 
+     * @returns The ID of the layer.
      */
     public getLayerId(): string | undefined {
         return this.layerId;
     }
 
     /**
-     * @brief set the metadata of the partitions to upload.
-     * @param publishPartitions  The partitions metadata to be published.
-     * @note Required.
-     * @returns reference to this object
+     * Sets the metadata of the partitions to upload.
+     * 
+     * @param publishPartitions The partitions metadata to upload.
+     * 
+     * @returns A reference to this object.
      */
     public withPartitions(
         publishPartitions: PublishPartitions
@@ -80,19 +85,21 @@ export class UploadPartitionsRequest {
     }
 
     /**
-     * @brief get the the partitions.
-     * @returns The the partition metatada.
+     * Gets the metadata of partitions.
+     * 
+     * @returns The metadata of partitions.
      */
     public getPartitions(): PublishPartitions | undefined {
         return this.publishPartitions;
     }
 
     /**
-     * @brief set the billing tag.
-     * @param billing_tag An optional free-form tag which is used for grouping
-     * billing records together. If supplied, it must be between 4 - 16
-     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
-     * @note Optional.
+     * Sets the billing tag.
+     * 
+     * @param tag The free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
+     * 
+     * @returns A reference to this object.
      */
     public withBillingTag(tag: string): UploadPartitionsRequest {
         this.billingTag = tag;
@@ -100,7 +107,9 @@ export class UploadPartitionsRequest {
     }
 
     /**
-     * @return Billing Tag previously set or undefined.
+     * Gets the billing tag (if it was set).
+     * 
+     * @return The billing tag or `undefined` if it was not set.
      */
     public getBillingTag(): string | undefined {
         return this.billingTag;

--- a/@here/olp-sdk-dataservice-write/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/VersionedLayerClient.ts
@@ -42,41 +42,42 @@ import {
 } from "@here/olp-sdk-dataservice-write";
 
 /**
- * Parameters for use to initialize VolatileLayerClient.
+ * Parameters used to initialize `VersionedLayerClient`.
  */
 export interface VersionedLayerClientParams {
-    // [[HRN]] instance of the catalog hrn.
+    // An instance of the catalog [[HRN]].
     catalogHrn: HRN;
     // The [[OlpClientSettings]] instance.
     settings: OlpClientSettings;
 }
 
 /**
- * Describes a versioned layer and provides the possibility to push the data to the versioned layers.
+ * Describes a versioned layer and provides a possibility to publish data to it.
  */
 export class VersionedLayerClient {
     private readonly apiVersion = "v1";
 
     /**
-     * Creates the [[VersionedLayerClient]] instance with VersionedLayerClientParams.
+     * Creates the [[VersionedLayerClient]] instance with `VersionedLayerClientParams`.
      *
-     * @param params parameters for use to initialize VersionedLayerClient.
+     * @param params The parameters that are used to initialize `VersionedLayerClient`.
      */
     constructor(private readonly params: VersionedLayerClientParams) {}
 
     /**
-     * Checks that the datahandle is not used.
-     * Data handles must be unique within the layer across all versions.
-     * In case data handle exists, a new one needs to be generated and checked again until
-     * one is found that is not present in the blob store.
-     * @param request CheckDataExistsRequest with required params.
-     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * Checks whether the data handle is not used.
+     * 
+     * Data handles must be unique within a layer across all versions.
+     * If the data handle exists, generate a new one and check it again 
+     * to be sure that it is not present in the blob store.
+     * 
+     * @param request `CheckDataExistsRequest` with the required params.
+     * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
-     *
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     *
-     * @returns A promise void if data handle exists.
-     * Rejects with http response if DataHandle is not exists (404 status) or any http error.
+     * 
+     * @returns The `Promise` void if the data handle exists.
+     * If the data handle does not exist, rejects with an HTTP response (404 status) or an HTTP error.
      */
     public async checkDataExists(
         request: CheckDataExistsRequest,
@@ -123,20 +124,18 @@ export class VersionedLayerClient {
     }
 
     /**
-     * Gets the latest version of a catalog.
+     * Gets the latest version of the catalog.
      *
      * The default value is -1. By convention -1 indicates the virtual initial version before
      * the first publication that has version 0.
      *
-     * @param billingTag An optional free-form tag that is used for grouping billing records together.
-     * If supplied, it must be 4&ndash;16 characters long and contain only alphanumeric ASCII characters [A-Za-z0-9].
-     *
-     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * @param billingTag The free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
+     * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
-     *
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
      *
-     * @returns A promise of the HTTP response that contains the payload with the latest version.
+     * @returns The `Promise` of the HTTP response that contains the payload with the latest version.
      */
     public async getBaseVersion(
         billingTag?: string,
@@ -166,20 +165,20 @@ export class VersionedLayerClient {
     }
 
     /**
-     * Initializes a new publication for publishing metadata.
+     * Starts a new publication.
+     * 
      * Determines the publication type based on the provided layer IDs.
      * A publication can only consist of layer IDs that have the same layer type.
-     * For example, you can have a publication for multiple layers of type versioned,
-     * but you cannot have a single publication that publishes to both versioned and stream layers.
+     * For example, you can have a publication for multiple versioned layers,
+     * but you cannot have a single publication that publishes data to both versioned and stream layers.
      *
-     * In addition, you may only have one versioned publication in process at a time.
-     * You cannot have multiple active publications to the same catalog for versioned layer types.
-     * The request field versionDependencies is optional and is used for versioned layers to declare version dependencies.
+     * Also, you can only have one versioned-layer publication in progress at a time.
+     * You cannot have multiple active publications to the same catalog for versioned layers.
+     * The version dependencies request field is optional and is used for versioned layers to declare version dependencies.
      *
-     * @param request details of the batch operation to start
-     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * @param request The details of the batch operation that you want to start.
+     * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
-     *
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
      */
     public async startBatch(
@@ -219,14 +218,14 @@ export class VersionedLayerClient {
     }
 
     /**
-     * @breaf Gives the user the possibility to upload one partition blob and metadata at once
-     * @param request PublishSinglePartitionRequest with needed params
-     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * Uploads one partition blob and metadata at once.
+     * 
+     * @param request The `PublishSinglePartitionRequest` object with the needed parameters.
+     * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
-     *
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     *
-     * @returns Promise resolves if the operation was successful. Rejects if unsuccessful.
+     * 
+     * @returns The `Promise` resolves if the operation was successful; rejects otherwise.
      */
     public async publishToBatch(
         request: PublishSinglePartitionRequest,
@@ -328,17 +327,17 @@ export class VersionedLayerClient {
     }
 
     /**
-     * Cancels a publication if it has not yet been submitted.
-     * Will fail if attempting to cancel a submitted publication.
+     * Cancels the publication if it has not been submitted.
+     * 
+     * Fails if you attempt to cancel a submitted publication.
      * This allows the specified publication to be abandoned.
      *
-     * @param request details of the cancel operation.
-     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * @param request The details of the cancel operation.
+     * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
-     *
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     *
-     * @returns True if the operation was successful. Rejects error if unsuccessful.
+     * 
+     * @returns True if the operation was successful; rejects with an error otherwise.
      */
     public async cancelBatch(
         request: CancelBatchRequest,
@@ -374,14 +373,13 @@ export class VersionedLayerClient {
     }
 
     /**
-     * Retrieves the publication details.
+     * Gets the publication details.
      *
-     * @param request details of the retrieve operation.
-     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * @param request The details of the `GET` operation.
+     * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
-     *
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     *
+     * 
      * @returns The publication details.
      */
     public async getBatch(
@@ -418,24 +416,24 @@ export class VersionedLayerClient {
     }
 
     /**
-     * Submits the publication, resp. a batch, and initiates post processing if necessary.
+     * Submits the publication (that is a batch) and initiates post-processing if necessary.
+     * 
+     * You cannot modify or interrupt the publication process, so double-check the publication details before submitting it.
      *
-     * Publication state becomes `Submitted` directly after submission and `Succeeded` after successful processing.
-     * Users can only complete a publication which is in state `Initialized`.
+     * The publication state becomes `Submitted` directly after submission and `Succeeded` after successful processing.
+     * You can only complete a publication that is in the `Initialized` state.
      *
-     * Once the user triggered to complete a publication,
-     * he must request the status of the publication regularly until the status becomes `Succeeded`.
+     * Once you trigger to complete a publication,
+     * request the status of the publication regularly until the status becomes `Succeeded`.
      *
-     * After submitting the publication, the metadata processing will begin.
-     * You will be unable to modify or interrupt the publication process so make sure that you are ready before submitting the publication.
+     * When you submit the publication, the metadata processing starts.
      *
-     * @param request details of the complete publish.
-     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * @param request The details of the publication completion.
+     * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
-     *
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     *
-     * @returns Promise resolves if the operation was successful. Rejects if unsuccessful.
+     * 
+     * @returns The `Promise` resolves if the operation was successful; rejects otherwise.
      */
     public async completeBatch(
         request: CompleteBatchRequest,
@@ -471,31 +469,30 @@ export class VersionedLayerClient {
     }
 
     /**
-     * Uploads data to the service
+     * Uploads data to the service.
      *
-     * If you are uploading more than 50 MB of data,
-     * the data splits into parts and uploads each part individually.
+     * If you are upload more than 50 MB of data,
+     * the data is split into parts, and each part is uploaded individually.
      * The size of each part is 5 MB, except the last part.
      *
-     * @param request details of the uploading data.
-     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * @param request The details of the data upload process.
+     * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
-     *
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
      *
-     * @returns Promise resolves with UploadBlobResult.
+     * @returns The `Promise` resolves with `UploadBlobResult`.
      */
     public async uploadBlob(
         request: UploadBlobRequest,
         abortSignal?: AbortSignal
     ): Promise<UploadBlobResult> {
         /**
-         * If data size is less then 50Mb we can upload all data in one request
-         * If more than 50Mb, we should split the data by 5Mb chunks and upload
-         * chunk by chunk, colloeting ETags from responses and than submit all tags by PUT request.
+         * If the data size is less then 50 MB, we can upload all data in one request.
+         * If more than 50 MB, we split the data in chunks of 5 MB and upload chunk by chunk.
+         * We collect ETags from responses, and then submit all tags using the `PUT` request.
          */
-        const chunkSize = 5242880; // 1024 * 1024 * 5 = 5MB
-        const maxDataSizeForOneRequestUpload = 52428800; // 1024 * 1024 * 50 = 50Mb
+        const chunkSize = 5242880; // 1024 * 1024 * 5 = 5 MB
+        const maxDataSizeForOneRequestUpload = 52428800; // 1024 * 1024 * 50 = 5 Mb
 
         const billingTag = request.getBillingTag();
         const layerId = request.getLayerId();
@@ -613,28 +610,26 @@ export class VersionedLayerClient {
     /**
      * Uploads metadata to the service.
      *
-     * When all data have been uploaded,
-     * you need to generate the metadata which will be used to represent
-     * your data inside the HERE platform.
-     * At a minimum, your metadata must consist of a partition ID and the data handle you used to upload your data.
-     * For a complete description of the fields you can set, @see [[PublishPartition]].
+     * When all data is uploaded, you need to
+     * generate metadata to represent your data inside the HERE platform.
+     * At a minimum, your metadata must consist of a partition ID and the data handle that you used to upload your data.
+     * For a complete description of the fields that you can set, @see [[PublishPartition]].
      *
      * The maximum number of partitions you can upload and publish in one request is 1,000.
-     * If you have more than 1,000 partitions you want to upload,
-     * upload the data for the first 1,000 partitions
-     * then upload the metadata for those 1,000 partitions.
-     * Then, continue to the next set of partitions.
+     * If you have more than 1,000 partitions that you want to upload,
+     * upload the data for the first 1,000 partitions, and
+     * then upload the metadata for these 1,000 partitions.
+     * Then, continue with the next set of partitions.
      * Do not wait until all data is uploaded before uploading metadata.
      * Doing so will result in poor performance.
-     * Instead, upload data, then metadata, and repeat as needed until all your data and corresponding metadata is uploaded.
+     * Instead, upload data, then metadata, and repeat if needed until all your data and corresponding metadata is uploaded.
      *
-     * @param request details of the uploading metadata.
-     * @param abortSignal An optional signal object that allows you to communicate with a request (such as the `fetch` request)
+     * @param request The details of the metadata upload process.
+     * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
-     *
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
      *
-     * @returns Promise resolves with 204 status if success.
+     * @returns The `Promise` resolves with the 204 status code if the upload was successful.
      */
     public async uploadPartitions(
         request: UploadPartitionsRequest,
@@ -686,18 +681,17 @@ export class VersionedLayerClient {
     }
 
     /**
-     * Generates the UUID and use it as datahandle.
-     * A retry logic in case datahandle is already present is a loop of 3 tries
+     * Generates the UUID and uses it as a data handle.
+     * A retry logic in case the data handle is already present is a loop of 3 tries,
      * and each time we generate a new UUID and retry.
      *
-     * If all thies was not success, the method rejects the promise with Error.
+     * If all tries are not successful, the method rejects the `Promise` with an error.
      *
-     * @param layerId The id of layer to check if data exist
-     * @param billingTag An optional free-form tag which is used for grouping
-     * billing records together. If supplied, it must be between 4 - 16
-     * characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
+     * @param layerId The ID of the layer to check if data exist.
+     * @param billingTag The free-form tag that is used for grouping billing records together.
+     * If supplied, it must be 4–16 characters long and contain only alphanumeric ASCII characters [A–Za–z0–9].
      *
-     * @returns A promise with generated datahandle or rejects if was not succeed.
+     * @returns A `Promise` with the generated data handle; otherwise, the `Promise` rejects.
      */
     private async generateDatahandle(
         layerId: string,


### PR DESCRIPTION
* All optional parameters get the `Optional` tag
in the API reference by default. No need to repeat it.
* If a parameter is not marked as optional, it's required by default.
No need to repeat it.
* Add missing descriptions.
* Remove tags that are not supported by TypeDoc (`@brief`)
* Modify wrong parameters in descriptions.
* Review the documentation for grammar and consistency.

Relates-To: OLPEDGE-2250

Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>