### PR TITLE
Use RequestFactory from core.

### DIFF
--- a/@here/olp-sdk-core/test/unit/RequestBuilderFactory.test.ts
+++ b/@here/olp-sdk-core/test/unit/RequestBuilderFactory.test.ts
@@ -45,7 +45,7 @@ class MockedHrn {
 }
 
 class MockedOlpClientSettings {
-    private keyValueCache = new Map();
+    private keyValueCache = new lib.LRUCache(50);
 
     constructor() {}
     get cache() {
@@ -55,18 +55,107 @@ class MockedOlpClientSettings {
         return "test-env";
     }
     get token() {
-        return Promise.resolve("mocked-token");
+        return () => Promise.resolve("mocked-token");
     }
     get downloadManager() {
         return {
-            download: (url: string) => Promise.resolve("mocked-results")
+            download: (url: string) =>
+                Promise.resolve({
+                    status: 200,
+                    json: () =>
+                        Promise.resolve([
+                            {
+                                api: "account",
+                                version: "v1",
+                                baseURL: "https://mocked.url",
+                                parameters: {}
+                            },
+                            {
+                                api: "account",
+                                version: "v1.1",
+                                baseURL:
+                                    "https://mocked.url/authorization/v1.1",
+                                parameters: {}
+                            },
+                            {
+                                api: "artifact",
+                                version: "v1",
+                                baseURL:
+                                    "https://artifact.api.platform.here.com/v1",
+                                parameters: {}
+                            },
+                            {
+                                api: "authentication",
+                                version: "v1.1",
+                                baseURL:
+                                    "https://mocked.url/authentication/v1.1",
+                                parameters: {}
+                            },
+                            {
+                                api: "authorization",
+                                version: "v1.1",
+                                baseURL:
+                                    "https://mocked.url/authorization/v1.1",
+                                parameters: {}
+                            },
+                            {
+                                api: "config",
+                                version: "v1",
+                                baseURL:
+                                    "https://config.data.api.platform.here.com/config/v1",
+                                parameters: {}
+                            },
+                            {
+                                api: "consent",
+                                version: "v0",
+                                baseURL:
+                                    "https://consent.api.platform.here.com/consent-service/v0",
+                                parameters: {}
+                            },
+                            {
+                                api: "consent",
+                                version: "v1",
+                                baseURL:
+                                    "https://consent.api.platform.here.com/consent-service/v1",
+                                parameters: {}
+                            },
+                            {
+                                api: "location-service-registry",
+                                version: "v1",
+                                baseURL:
+                                    "https://registry.services.api.platform.here.com/v1",
+                                parameters: {}
+                            },
+                            {
+                                api: "lookup",
+                                version: "v1",
+                                baseURL:
+                                    "https://api-lookup.data.api.platform.here.com/lookup/v1",
+                                parameters: {}
+                            },
+                            {
+                                api: "marketplace",
+                                version: "v1",
+                                baseURL:
+                                    "https://marketplace.api.platform.here.com/api/v1",
+                                parameters: {}
+                            },
+                            {
+                                api: "pipelines",
+                                version: "v2",
+                                baseURL:
+                                    "https://pipelines.api.platform.here.com/pipeline-service",
+                                parameters: {}
+                            }
+                        ])
+                })
         };
     }
 }
 
 class MockedApiCacheRepository {
     private readonly hrn: string;
-    constructor(private readonly cache: Map<string, string>, hrn?: MockedHrn) {
+    constructor(private readonly cache: any, hrn?: MockedHrn) {
         this.hrn = hrn ? hrn.toString() : "plathorm-api";
     }
 

--- a/@here/olp-sdk-dataservice-read/lib/client/ArtifactClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/ArtifactClient.ts
@@ -17,9 +17,12 @@
  * License-Filename: LICENSE
  */
 
-import { OlpClientSettings } from "@here/olp-sdk-core";
+import { OlpClientSettings, RequestFactory } from "@here/olp-sdk-core";
 import { ArtifactApi } from "@here/olp-sdk-dataservice-api";
-import { RequestFactory, SchemaDetailsRequest, SchemaRequest } from "..";
+import {
+    SchemaDetailsRequest,
+    SchemaRequest
+} from "@here/olp-sdk-dataservice-read";
 
 /**
  * Gets schema metadata and data from the platform Artifact Service.

--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogClient.ts
@@ -21,12 +21,15 @@ import {
     ApiName,
     DataStoreRequestBuilder,
     HRN,
-    OlpClientSettings
+    OlpClientSettings,
+    RequestFactory
 } from "@here/olp-sdk-core";
 import { ConfigApi, MetadataApi } from "@here/olp-sdk-dataservice-api";
-import { CatalogVersionRequest, RequestFactory } from "..";
-import { CatalogRequest } from "./CatalogRequest";
-import { LayerVersionsRequest } from "./LayerVersionsRequest";
+import {
+    CatalogRequest,
+    CatalogVersionRequest,
+    LayerVersionsRequest
+} from "@here/olp-sdk-dataservice-read";
 
 /**
  * Interacts with the `DataStore` catalog.

--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogRequest.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { validateBillingTag } from "..";
+import { validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  * Prepares information for calls to get catalog metadata from the platform Config Service.

--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogVersionRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogVersionRequest.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { validateBillingTag } from "..";
+import { validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  * Prepares information for calls to the platform Artifact Service.
@@ -30,7 +30,7 @@ export class CatalogVersionRequest {
     /**
      * Gets a catalog start version (exclusive) for the request. Default is -1. By convention -1
      * indicates the virtual initial version before the first publication that has version 0.
-     * 
+     *
      * @return The catalog start version.
      */
     public getStartVersion(): number | undefined {
@@ -40,7 +40,7 @@ export class CatalogVersionRequest {
     /**
      * Gets a catalog end version (inclusive) for the request. If not defined, then the latest catalog
      * version is fethced and used.
-     * 
+     *
      * @return The catalog end version.
      */
     public getEndVersion(): number | undefined {
@@ -72,7 +72,7 @@ export class CatalogVersionRequest {
     /**
      * An optional free-form tag that is used for grouping billing records together.
      * If supplied, it must be 4&ndash;16 characters long and contain only alphanumeric ASCII characters [A-Za-z0-9].
-     * 
+     *
      * @param tag The `BillingTag` string.
      * @return The updated [[CatalogVersionRequest]] instance that you can use to chain methods.
      */
@@ -83,7 +83,7 @@ export class CatalogVersionRequest {
 
     /**
      * Gets a billing tag to group billing records together.
-     * 
+     *
      * @return The `BillingTag` string.
      */
     public getBillingTag(): string | undefined {

--- a/@here/olp-sdk-dataservice-read/lib/client/CatalogsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/CatalogsRequest.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { validateBillingTag } from "..";
+import { validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  * Prepares information for calls to get catalogs from the platform Config Service.
@@ -28,7 +28,7 @@ export class CatalogsRequest {
 
     /**
      *  Gets a schema HERE Resource Name (HRN) for the request.
-     * 
+     *
      * @return The schema HRN.
      */
     public getSchema(): string | undefined {
@@ -39,7 +39,7 @@ export class CatalogsRequest {
      * Sets a value of a layer schema HERE Resource Name (HRN) that is used in the `getCatalogs` method of the [[ConfigClient]] instance.
      * If the schema is set, the `getCatalogs` method returns catalogs witch have a layer or layers with the specific schema HRN.
      * If the schema is not set, the filter returns all of the catalogs to which you have access.
-     * 
+     *
      * @param schemaHrn The layer schema HRN.
      * @return The updated [[CatalogRequest]] instance that you can use to chain methods.
      */
@@ -51,7 +51,7 @@ export class CatalogsRequest {
     /**
      * An optional free-form tag that is used for grouping billing records together.
      * If supplied, it must be 4&ndash;16 characters long and contain only alphanumeric ASCII characters [A-Za-z0-9].
-     * 
+     *
      * @param tag The `BillingTag` string.
      * @return The updated [[CatalogsRequest]] instance that you can use to chain methods.
      */
@@ -62,7 +62,7 @@ export class CatalogsRequest {
 
     /**
      * Gets a billing tag to group billing records together.
-     * 
+     *
      * @return The `BillingTag` string.
      */
     public getBillingTag(): string | undefined {

--- a/@here/olp-sdk-dataservice-read/lib/client/ConfigClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/ConfigClient.ts
@@ -17,9 +17,9 @@
  * License-Filename: LICENSE
  */
 
-import { OlpClientSettings } from "@here/olp-sdk-core";
+import { OlpClientSettings, RequestFactory } from "@here/olp-sdk-core";
 import { ConfigApi } from "@here/olp-sdk-dataservice-api";
-import { CatalogsRequest, RequestFactory } from "..";
+import { CatalogsRequest } from "@here/olp-sdk-dataservice-read";
 
 /**
  * A client for the platform Config Service.

--- a/@here/olp-sdk-dataservice-read/lib/client/DataRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/DataRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { FetchOptions } from "@here/olp-sdk-core";
-import { QuadKey, validateBillingTag } from "..";
+import { QuadKey, validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  *  Prepares information for calls to get data from the HERE Blob Service.

--- a/@here/olp-sdk-dataservice-read/lib/client/IndexLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/IndexLayerClient.ts
@@ -21,10 +21,11 @@ import {
     ApiName,
     DataStoreRequestBuilder,
     HRN,
-    OlpClientSettings
+    OlpClientSettings,
+    RequestFactory
 } from "@here/olp-sdk-core";
 import { BlobApi, IndexApi } from "@here/olp-sdk-dataservice-api";
-import { IndexQueryRequest, RequestFactory } from "..";
+import { IndexQueryRequest } from "@here/olp-sdk-dataservice-read";
 
 /**
  * Parameters for use to initialize IndexLayerClient.

--- a/@here/olp-sdk-dataservice-read/lib/client/LayerVersionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/LayerVersionsRequest.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { validateBillingTag } from "..";
+import { validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /** Prepares information for calls to get layer versions of a specific catalog version. */
 export class LayerVersionsRequest {
@@ -26,7 +26,7 @@ export class LayerVersionsRequest {
 
     /**
      * Gets a catalog version.
-     * 
+     *
      * @returns The catalog version.
      */
     public getVersion(): number | undefined {

--- a/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
@@ -19,7 +19,10 @@
 
 import { FetchOptions } from "@here/olp-sdk-core";
 import { AdditionalFields } from "@here/olp-sdk-dataservice-api";
-import { validateBillingTag, validatePartitionsIdsList } from "..";
+import {
+    validateBillingTag,
+    validatePartitionsIdsList
+} from "@here/olp-sdk-dataservice-read";
 
 /**
  * Prepares information for calls to get partitions metadata from the Metadata Service API.

--- a/@here/olp-sdk-dataservice-read/lib/client/QuadKeyPartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QuadKeyPartitionsRequest.ts
@@ -18,7 +18,11 @@
  */
 
 import { AdditionalFields } from "@here/olp-sdk-dataservice-api";
-import { QuadKey, QuadTreeIndexDepth, validateBillingTag } from "..";
+import {
+    QuadKey,
+    QuadTreeIndexDepth,
+    validateBillingTag
+} from "@here/olp-sdk-dataservice-read";
 
 /**
  * Prepares information for calls to get quadtree metadata from the Query Service API.

--- a/@here/olp-sdk-dataservice-read/lib/client/QuadTreeIndexRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QuadTreeIndexRequest.ts
@@ -19,7 +19,7 @@
 
 import { HRN } from "@here/olp-sdk-core";
 import { AdditionalFields } from "@here/olp-sdk-dataservice-api";
-import { QuadKey, validateBillingTag } from "..";
+import { QuadKey, validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  * The recursion depth of the quadtree.
@@ -56,7 +56,7 @@ export class QuadTreeIndexRequest {
         private catalogHrn: HRN,
         private layerId: string,
         private layerType: "versioned" | "volatile" = "versioned"
-    ) { }
+    ) {}
 
     /**
      * The version of the catalog against which you want to run the query.

--- a/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
@@ -17,7 +17,12 @@
  * License-Filename: LICENSE
  */
 
-import { FetchOptions, HRN, OlpClientSettings } from "@here/olp-sdk-core";
+import {
+    FetchOptions,
+    HRN,
+    OlpClientSettings,
+    RequestFactory
+} from "@here/olp-sdk-core";
 import {
     AdditionalFields,
     MetadataApi,
@@ -25,12 +30,11 @@ import {
 } from "@here/olp-sdk-dataservice-api";
 import {
     isValid,
+    MetadataCacheRepository,
     mortonCodeFromQuadKey,
     PartitionsRequest,
-    QuadTreeIndexRequest,
-    RequestFactory
-} from "..";
-import { MetadataCacheRepository } from "../cache/MetadataCacheRepository";
+    QuadTreeIndexRequest
+} from "@here/olp-sdk-dataservice-read";
 
 /**
  * A client for the Query Service API that provides a way to get information (metadata)

--- a/@here/olp-sdk-dataservice-read/lib/client/SchemaDetailsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/SchemaDetailsRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { HRN } from "@here/olp-sdk-core";
-import { validateBillingTag } from "..";
+import { validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  * Prepares information for calls to the platform Artifact Service.

--- a/@here/olp-sdk-dataservice-read/lib/client/SchemaRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/SchemaRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { ArtifactApi } from "@here/olp-sdk-dataservice-api";
-import { validateBillingTag } from "..";
+import { validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  * Prepares information for calls to the platform Artifact Service.

--- a/@here/olp-sdk-dataservice-read/lib/client/StatisticsClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/StatisticsClient.ts
@@ -20,15 +20,15 @@
 import {
     DataStoreRequestBuilder,
     HRN,
-    OlpClientSettings
+    OlpClientSettings,
+    RequestFactory
 } from "@here/olp-sdk-core";
 import { CoverageApi } from "@here/olp-sdk-dataservice-api";
 import {
     CoverageDataType,
-    RequestFactory,
     StatisticsRequest,
     SummaryRequest
-} from "..";
+} from "@here/olp-sdk-dataservice-read";
 
 /**
  * A client for the platform Statistics Service.

--- a/@here/olp-sdk-dataservice-read/lib/client/StatisticsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/StatisticsRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { HRN } from "@here/olp-sdk-core";
-import { validateBillingTag } from "..";
+import { validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  * A map type that is supported by the platform Statistics Service.

--- a/@here/olp-sdk-dataservice-read/lib/client/StreamLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/StreamLayerClient.ts
@@ -20,16 +20,16 @@
 import {
     DataStoreRequestBuilder,
     HRN,
-    OlpClientSettings
+    OlpClientSettings,
+    RequestFactory
 } from "@here/olp-sdk-core";
 import { BlobApi, StreamApi } from "@here/olp-sdk-dataservice-api";
 import {
     PollRequest,
-    RequestFactory,
     SeekRequest,
     SubscribeRequest,
     UnsubscribeRequest
-} from "..";
+} from "@here/olp-sdk-dataservice-read";
 
 export interface StreamLayerClientParams {
     // The HERE Resource Name (HRN) of the catalog from which you want to get partitions metadata and data.

--- a/@here/olp-sdk-dataservice-read/lib/client/SummaryRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/SummaryRequest.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 import { HRN } from "@here/olp-sdk-core";
-import { validateBillingTag } from "..";
+import { validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  * Prepares information for calls to get a summary from the platform Statistics Service.

--- a/@here/olp-sdk-dataservice-read/lib/client/TileRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/TileRequest.ts
@@ -24,7 +24,7 @@ import {
     RequestFactory
 } from "@here/olp-sdk-core";
 import { MetadataApi } from "@here/olp-sdk-dataservice-api";
-import { QuadKey, validateBillingTag } from "..";
+import { QuadKey, validateBillingTag } from "@here/olp-sdk-dataservice-read";
 
 /**
  * Parameters used to get a tile.

--- a/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VersionedLayerClient.ts
@@ -24,21 +24,21 @@ import {
     HRN,
     HttpError,
     OlpClientSettings,
+    RequestFactory,
     STATUS_CODES
 } from "@here/olp-sdk-core";
 import { BlobApi, MetadataApi, QueryApi } from "@here/olp-sdk-dataservice-api";
 import {
     DataRequest,
+    getTile,
     MetadataCacheRepository,
     PartitionsRequest,
     QuadKeyPartitionsRequest,
     QuadTreeIndexRequest,
     QueryClient,
-    RequestFactory
-} from "..";
-import { getTile } from "../utils";
-import { TileRequest, TileRequestParams } from "./TileRequest";
-
+    TileRequest,
+    TileRequestParams
+} from "@here/olp-sdk-dataservice-read";
 /**
  * Parameters for use to initialize VersionLayerClient.
  */

--- a/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/VolatileLayerClient.ts
@@ -24,6 +24,7 @@ import {
     HRN,
     HttpError,
     OlpClientSettings,
+    RequestFactory,
     STATUS_CODES
 } from "@here/olp-sdk-core";
 import {
@@ -39,10 +40,9 @@ import {
     QuadKeyPartitionsRequest,
     QuadTreeIndexRequest,
     QueryClient,
-    RequestFactory,
     TileRequest,
     TileRequestParams
-} from "..";
+} from "@here/olp-sdk-dataservice-read";
 
 /**
  * Parameters for use to initialize VolatileLayerClient.

--- a/@here/olp-sdk-dataservice-read/lib/utils/RequestBuilderFactory.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/RequestBuilderFactory.ts
@@ -21,4 +21,77 @@
  * @deprecated This file will be removed by 02.2021. Please use the same from  the `@here/olp-sdk-core` package.
  */
 
-export * from "@here/olp-sdk-core/lib/utils/RequestBuilderFactory";
+import {
+    ApiCacheRepository,
+    ApiName,
+    DataStoreRequestBuilder,
+    getEnvLookUpUrl,
+    HRN,
+    HttpError,
+    OlpClientSettings,
+    RequestFactory as CoreRequestFactory
+} from "@here/olp-sdk-core";
+import { LookupApi } from "@here/olp-sdk-dataservice-api";
+const MILLISECONDS_IN_SECOND = 1000;
+
+/**
+ * @deprecated This class will be removed by 02.2021. Please use the same from  the `@here/olp-sdk-core` package.
+ * A helper utils that makes the `Request` object with the base URLs of the API Lookup Service, token callback, and download manager.
+ *
+ * Also, you can use it to get the base URLs of the API Lookup Service.
+ */
+export class RequestFactory {
+    /**
+     * Factory method for building [[DataStoreRequestBuilder]].
+     *
+     * @param serviceName The name of the service in the API.
+     * @param serviceVersion The version of the service.
+     * @param settings The [[OlpClientSettings]] instance.
+     * @param hrn A HERE Resource Name ([[HRN]]) of the catalog.
+     * @param abortSignal A signal object that allows you to communicate with a request (such as the `fetch` request)
+     * and, if required, abort it using the `AbortController` object.
+     *
+     * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+     *
+     * @returns The Promise with constructed [[DataStoreRequestBuilder]].
+     */
+    public static async create(
+        serviceName: ApiName,
+        serviceVersion: string,
+        settings: OlpClientSettings,
+        hrn?: HRN,
+        abortSignal?: AbortSignal
+    ): Promise<DataStoreRequestBuilder> {
+        return CoreRequestFactory.create(
+            serviceName,
+            serviceVersion,
+            settings,
+            hrn,
+            abortSignal
+        );
+    }
+
+    /**
+     * Gets a base URL of the API service that supports caching.
+     *
+     * @param serviceName The name of the API service.
+     * @param serviceVersion The version of the service.
+     * @param settings The [[OlpClientSettings]] instance.
+     * @param hrn The [[HRN]] of the catalog.
+     *
+     * @return The Promise with the base URL of the service.
+     */
+    public static async getBaseUrl(
+        serviceName: ApiName,
+        serviceVersion: string,
+        settings: OlpClientSettings,
+        hrn?: HRN
+    ): Promise<string> {
+        return CoreRequestFactory.getBaseUrl(
+            serviceName,
+            serviceVersion,
+            settings,
+            hrn
+        );
+    }
+}

--- a/@here/olp-sdk-dataservice-read/lib/utils/getTile.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/getTile.ts
@@ -17,20 +17,19 @@
  * License-Filename: LICENSE
  */
 
-import { FetchOptions, HRN, TileKey } from "@here/olp-sdk-core";
+import { FetchOptions, HRN, RequestFactory, TileKey } from "@here/olp-sdk-core";
 import { BlobApi } from "@here/olp-sdk-dataservice-api";
 import { Index as QuadTreeIndex } from "@here/olp-sdk-dataservice-api/lib/query-api";
 import {
+    ApiName,
     OlpClientSettings,
     QuadTreeIndexCacheRepository,
+    QuadTreeIndexDepth,
     QuadTreeIndexRequest,
     QueryClient,
-    RequestFactory,
-    TileRequest
-} from "..";
-import { ApiName } from "../cache";
-import { QuadTreeIndexDepth, TileRequestParams } from "../client";
-
+    TileRequest,
+    TileRequestParams
+} from "@here/olp-sdk-dataservice-read";
 /**
  * Parameters used to get a tile.
  */

--- a/@here/olp-sdk-dataservice-read/test/unit/ArtifactClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/ArtifactClient.test.ts
@@ -21,9 +21,9 @@ import sinon = require("sinon");
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
-import * as dataServiceRead from "../../lib";
+import * as dataServiceRead from "@here/olp-sdk-dataservice-read";
 import { ArtifactApi } from "@here/olp-sdk-dataservice-api";
-import { HttpError } from "@here/olp-sdk-core";
+import { HttpError, RequestFactory } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 
@@ -50,10 +50,7 @@ describe("ArtifactClient", function() {
         olpClientSettingsStub = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
         );
-        getBaseUrlRequestStub = sandbox.stub(
-            dataServiceRead.RequestFactory,
-            "getBaseUrl"
-        );
+        getBaseUrlRequestStub = sandbox.stub(RequestFactory, "getBaseUrl");
         getArtifactUsingGETStub = sandbox.stub(
             ArtifactApi,
             "getArtifactUsingGET"

--- a/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/CatalogClient.test.ts
@@ -24,7 +24,7 @@ import sinonChai = require("sinon-chai");
 import * as dataServiceRead from "../../lib";
 import { ConfigApi, MetadataApi } from "@here/olp-sdk-dataservice-api";
 
-import { HttpError } from "@here/olp-sdk-core";
+import * as core from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 
@@ -53,9 +53,7 @@ describe("CatalogClient", function() {
 
     before(function() {
         sandbox = sinon.createSandbox();
-        let settings = sandbox.createStubInstance(
-            dataServiceRead.OlpClientSettings
-        );
+        let settings = sandbox.createStubInstance(core.OlpClientSettings);
         catalogClient = new dataServiceRead.CatalogClient(
             mockedHRN,
             (settings as unknown) as dataServiceRead.OlpClientSettings
@@ -68,10 +66,7 @@ describe("CatalogClient", function() {
         getCatalogStub = sandbox.stub(ConfigApi, "getCatalog");
         getListVersionsStub = sandbox.stub(MetadataApi, "listVersions");
         getEarliestVersionsStub = sandbox.stub(MetadataApi, "minimumVersion");
-        getBaseUrlRequestStub = sandbox.stub(
-            dataServiceRead.RequestFactory,
-            "getBaseUrl"
-        );
+        getBaseUrlRequestStub = sandbox.stub(core.RequestFactory, "getBaseUrl");
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 
@@ -111,7 +106,7 @@ describe("CatalogClient", function() {
 
     it("Should method getLatestVersion return HttpError when API crashes", async function() {
         const TEST_ERROR_CODE = 404;
-        const mockedError = new HttpError(
+        const mockedError = new core.HttpError(
             TEST_ERROR_CODE,
             "Can not get catalog latest version"
         );
@@ -258,7 +253,7 @@ describe("CatalogClient", function() {
 
     it("Should method getEarliestVersion return HttpError getting earliest catalog version", async function() {
         const TEST_ERROR_CODE = 404;
-        const mockedError = new HttpError(
+        const mockedError = new core.HttpError(
             TEST_ERROR_CODE,
             "Error getting earliest catalog version"
         );
@@ -330,7 +325,7 @@ describe("CatalogClient", function() {
 
     it("Should method getCatalog return HttpError when Can not load catalog configuration", async function() {
         const TEST_ERROR_CODE = 404;
-        const mockedError = new HttpError(
+        const mockedError = new core.HttpError(
             TEST_ERROR_CODE,
             "Can't load catalog configuration"
         );
@@ -447,7 +442,7 @@ describe("CatalogClient", function() {
 
     it("Should method getVersions return HttpError when API crashes", async function() {
         const TEST_ERROR_CODE = 404;
-        const mockedError = new HttpError(
+        const mockedError = new core.HttpError(
             TEST_ERROR_CODE,
             "Can't get versions"
         );

--- a/@here/olp-sdk-dataservice-read/test/unit/ConfigClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/ConfigClient.test.ts
@@ -21,6 +21,7 @@ import sinon = require("sinon");
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 import * as dataServiceRead from "../../lib";
+import { RequestFactory } from "@here/olp-sdk-core";
 import { ConfigApi } from "@here/olp-sdk-dataservice-api";
 
 chai.use(sinonChai);
@@ -37,7 +38,7 @@ describe("ConfigClient", function() {
 
     beforeEach(function() {
         sandbox
-            .stub(dataServiceRead.RequestFactory, "create")
+            .stub(RequestFactory, "create")
             .callsFake(() => Promise.resolve({} as any));
     });
 

--- a/@here/olp-sdk-dataservice-read/test/unit/IndexLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/IndexLayerClient.test.ts
@@ -22,7 +22,7 @@ import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
 import * as dataServiceRead from "../../lib";
-import { HttpError } from "@here/olp-sdk-core";
+import { HttpError, RequestFactory } from "@here/olp-sdk-core";
 import { IndexApi, BlobApi } from "@here/olp-sdk-dataservice-api";
 
 chai.use(sinonChai);
@@ -67,10 +67,7 @@ describe("IndexLayerClient", function() {
     beforeEach(function() {
         getBlobStub = sandbox.stub(BlobApi, "getBlob");
         getIndexStub = sandbox.stub(IndexApi, "performQuery");
-        getBaseUrlRequestStub = sandbox.stub(
-            dataServiceRead.RequestFactory,
-            "getBaseUrl"
-        );
+        getBaseUrlRequestStub = sandbox.stub(RequestFactory, "getBaseUrl");
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 

--- a/@here/olp-sdk-dataservice-read/test/unit/QueryClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/QueryClient.test.ts
@@ -23,6 +23,7 @@ import sinonChai = require("sinon-chai");
 
 import * as dataServiceRead from "../../lib";
 import { MetadataApi, QueryApi } from "@here/olp-sdk-dataservice-api";
+import { RequestFactory } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 
@@ -63,10 +64,7 @@ describe("QueryClient", function() {
         );
         getVersionStub = sandbox.stub(MetadataApi, "latestVersion");
         getPartitionsByIdStub = sandbox.stub(QueryApi, "getPartitionsById");
-        getBaseUrlRequestStub = sandbox.stub(
-            dataServiceRead.RequestFactory,
-            "getBaseUrl"
-        );
+        getBaseUrlRequestStub = sandbox.stub(RequestFactory, "getBaseUrl");
 
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });

--- a/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StatisticsClient.test.ts
@@ -23,6 +23,7 @@ import sinonChai = require("sinon-chai");
 
 import * as dataServiceRead from "../../lib";
 import { CoverageApi } from "@here/olp-sdk-dataservice-api";
+import { RequestFactory } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 
@@ -50,10 +51,7 @@ describe("StatistiscClient", function() {
         olpClientSettingsStub = sandbox.createStubInstance(
             dataServiceRead.OlpClientSettings
         );
-        getBaseUrlRequestStub = sandbox.stub(
-            dataServiceRead.RequestFactory,
-            "getBaseUrl"
-        );
+        getBaseUrlRequestStub = sandbox.stub(RequestFactory, "getBaseUrl");
         getDataCoverageSummaryStub = sandbox.stub(
             CoverageApi,
             "getDataCoverageSummary"

--- a/@here/olp-sdk-dataservice-read/test/unit/StreamLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/StreamLayerClient.test.ts
@@ -22,7 +22,7 @@ import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
 import * as dataServiceRead from "../../lib";
-import { HttpError } from "@here/olp-sdk-core";
+import { HttpError, RequestFactory } from "@here/olp-sdk-core";
 
 import { BlobApi, StreamApi } from "@here/olp-sdk-dataservice-api";
 
@@ -104,10 +104,7 @@ describe("StreamLayerClient", function() {
         commitOffsetsStub = sandbox.stub(StreamApi, "doCommitOffsets");
         unsubscribeStub = sandbox.stub(StreamApi, "deleteSubscription");
         seekOffsetsStub = sandbox.stub(StreamApi, "seekToOffset");
-        getBaseUrlRequestStub = sandbox.stub(
-            dataServiceRead.RequestFactory,
-            "getBaseUrl"
-        );
+        getBaseUrlRequestStub = sandbox.stub(RequestFactory, "getBaseUrl");
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 

--- a/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VersionedLayerClient.test.ts
@@ -21,10 +21,10 @@ import sinon = require("sinon");
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
-import * as dataServiceRead from "../../lib";
-import * as dataServiceApi from "@here/olp-sdk-dataservice-api";
+import * as dataServiceRead from "@here/olp-sdk-dataservice-read";
 import { BlobApi, MetadataApi, QueryApi } from "@here/olp-sdk-dataservice-api";
 import { Index } from "@here/olp-sdk-dataservice-api/lib/query-api";
+import { RequestFactory } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 
@@ -108,10 +108,7 @@ describe("VersionedLayerClient", function() {
         getPartitionsByIdStub = sandbox.stub(QueryApi, "getPartitionsById");
         getQuadTreeIndexStub = sandbox.stub(QueryApi, "quadTreeIndex");
         getVersionStub = sandbox.stub(MetadataApi, "latestVersion");
-        getBaseUrlRequestStub = sandbox.stub(
-            dataServiceRead.RequestFactory,
-            "getBaseUrl"
-        );
+        getBaseUrlRequestStub = sandbox.stub(RequestFactory, "getBaseUrl");
 
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });

--- a/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/VolatileLayerClient.test.ts
@@ -21,13 +21,13 @@ import sinon = require("sinon");
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
 
-import * as dataServiceRead from "../../lib";
+import * as dataServiceRead from "@here/olp-sdk-dataservice-read";
 import {
     MetadataApi,
     QueryApi,
     VolatileBlobApi
 } from "@here/olp-sdk-dataservice-api";
-import { PartitionsRequest } from "../../lib";
+import { RequestFactory } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 
@@ -98,10 +98,7 @@ describe("VolatileLayerClient", function() {
         getVersionStub = sandbox.stub(MetadataApi, "latestVersion");
         getPartitionsByIdStub = sandbox.stub(QueryApi, "getPartitionsById");
         getQuadTreeIndexStub = sandbox.stub(QueryApi, "quadTreeIndexVolatile");
-        getBaseUrlRequestStub = sandbox.stub(
-            dataServiceRead.RequestFactory,
-            "getBaseUrl"
-        );
+        getBaseUrlRequestStub = sandbox.stub(RequestFactory, "getBaseUrl");
         getBaseUrlRequestStub.callsFake(() => Promise.resolve(fakeURL));
     });
 

--- a/@here/olp-sdk-dataservice-read/test/unit/getTile.test.ts
+++ b/@here/olp-sdk-dataservice-read/test/unit/getTile.test.ts
@@ -18,12 +18,8 @@
  */
 
 import { assert } from "chai";
-import {
-    TileRequest,
-    getTile,
-    OlpClientSettings,
-    HRN
-} from "@here/olp-sdk-dataservice-read/lib";
+import { TileRequest, getTile } from "@here/olp-sdk-dataservice-read/lib";
+import { OlpClientSettings, HRN } from "@here/olp-sdk-core";
 
 describe("getTile", function() {
     const settings = new OlpClientSettings({


### PR DESCRIPTION
This CR mostly about changes in imports and
adaptations for tests.

As we have deprecated RequestFactory class in the
dataservice-read, we should use it from dataservice-core.

The unit tests have been updated because of starting using
RequestFactory from core makes the issues with mocking instances
in the tests.

Also the file
@here/olp-sdk-dataservice-read/lib/utils/RequestBuilderFactory.ts
was updated.

We've back the copy of class from core instead of importing from the
core, because of the circular dependency issue.
The SDK components do not use that file and that file will be removed
later as a deprecated.

Resolves: OLPEDGE-2001

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>