### PR TITLE
Update node-fetch to 2.6.1.

### DIFF
--- a/@here/olp-sdk-fetch/package.json
+++ b/@here/olp-sdk-fetch/package.json
@@ -48,7 +48,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "node-fetch": "2.6.0"
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/docs/examples/ts/package-lock.json
+++ b/docs/examples/ts/package-lock.json
@@ -33,7 +33,7 @@
           "resolved": "https://registry.npmjs.org/@here/olp-sdk-fetch/-/olp-sdk-fetch-1.3.0.tgz",
           "integrity": "sha512-OMmnfFK0VrUE2WIKDiGXt/qUf3JRL4HXmf5SFNBDhaTDS7MnsY3wFMvavsQ1poYEDl4O2AkVlaHG1U+RGmONEw==",
           "requires": {
-            "node-fetch": "2.6.0"
+            "node-fetch": "^2.6.0"
           }
         }
       }
@@ -43,7 +43,7 @@
       "resolved": "https://registry.npmjs.org/@here/olp-sdk-fetch/-/olp-sdk-fetch-1.4.0.tgz",
       "integrity": "sha512-2+pRc4D0qUuf0qq+8VOtyNaHeZreLR5yinh7WT0rK/iYSjW6fvh8ZLgPi5/OLhmcD65NvQHBICiz8KHUwxtCfg==",
       "requires": {
-        "node-fetch": "2.6.0"
+        "node-fetch": "^2.6.0"
       }
     },
     "@types/color-name": {
@@ -3176,9 +3176,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "^2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5688,10 +5688,10 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.0, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+node-fetch@^2.6.0, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-gyp@^5.0.2:
   version "5.1.1"


### PR DESCRIPTION
This CR fixes the security issue with node-fetch.

Resolves: OLPEDGE-2313

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>