### PR TITLE
Update typedoc config.

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -12,7 +12,10 @@
         "**/test/**/*.ts",
         "**/tests/**/*.ts",
         "**/dist/**/*.ts",
-        "**/scripts/*.ts"
+        "**/scripts/*.ts",
+        "@here/olp-sdk-authentication/lib.version.ts",
+        "@here/olp-sdk-authentication/lib/HttpError.ts",
+        "docs/examples/ts/example.ts"
     ],
     "readme": "README.md",
     "target": "ES6",


### PR DESCRIPTION
Adding to the `exclude` deprecated files and examples.

Relates-To: OLPEDGE-2316

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>