### PR TITLE
Add sentWith parameter for each request.

### DIFF
--- a/@here/olp-sdk-authentication/lib/UserAuth.ts
+++ b/@here/olp-sdk-authentication/lib/UserAuth.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { HttpError, LIB_VERSION } from "@here/olp-sdk-core";
+import { HttpError, SENT_WITH_PARAM } from "@here/olp-sdk-core";
 import { OAuthArgs, Token } from "./requestToken_common";
 
 /**
@@ -247,11 +247,14 @@ export class UserAuth {
             "Content-Type": "application/json"
         });
 
-        const request = await fetch(this.m_apiUrl + "verify/accessToken", {
-            method: "POST",
-            body: JSON.stringify(body),
-            headers
-        });
+        const request = await fetch(
+            this.m_apiUrl + "verify/accessToken" + `?${SENT_WITH_PARAM}`,
+            {
+                method: "POST",
+                body: JSON.stringify(body),
+                headers
+            }
+        );
 
         if (!request.ok) {
             return Promise.reject(
@@ -274,10 +277,13 @@ export class UserAuth {
             "Content-Type": "application/json"
         });
 
-        const request = await fetch(this.m_apiUrl + "user/me", {
-            method: "GET",
-            headers
-        });
+        const request = await fetch(
+            this.m_apiUrl + "user/me" + `?${SENT_WITH_PARAM}`,
+            {
+                method: "GET",
+                headers
+            }
+        );
 
         if (!request.ok) {
             return Promise.reject(

--- a/@here/olp-sdk-authentication/lib/requestToken_common.ts
+++ b/@here/olp-sdk-authentication/lib/requestToken_common.ts
@@ -17,7 +17,11 @@
  * License-Filename: LICENSE
  */
 
-import { HttpError, LIB_VERSION } from "@here/olp-sdk-core";
+import {
+    addSentWithParam,
+    HttpError,
+    SENT_WITH_PARAM
+} from "@here/olp-sdk-core";
 
 /**
  * Platform-specific parts of signing a request using HMAC algorithms.
@@ -116,7 +120,7 @@ async function getOAuthAuthorization(
         encodeURIComponent(args.url) +
         "&" +
         encodeURIComponent(
-            `oauth_consumer_key=${args.consumerKey}&oauth_nonce=${args.nonce}&oauth_signature_method=HMAC-SHA256&oauth_timestamp=${args.timestamp}&oauth_version=1.0`
+            `oauth_consumer_key=${args.consumerKey}&oauth_nonce=${args.nonce}&oauth_signature_method=HMAC-SHA256&oauth_timestamp=${args.timestamp}&oauth_version=1.0&${SENT_WITH_PARAM}`
         );
 
     const signature = await signLatin1(
@@ -167,7 +171,7 @@ export async function requestToken_common(
         headers
     };
 
-    const request = await fetch(args.url, requestInit);
+    const request = await fetch(addSentWithParam(args.url), requestInit);
 
     if (!request.ok) {
         return Promise.reject(

--- a/@here/olp-sdk-authentication/test/OAuth.test.ts
+++ b/@here/olp-sdk-authentication/test/OAuth.test.ts
@@ -20,7 +20,7 @@
 import * as chai from "chai";
 import { requestToken, Token, UserAuth } from "../index";
 
-import { HttpError } from "@here/olp-sdk-core";
+import { HttpError, SENT_WITH_PARAM } from "@here/olp-sdk-core";
 import fetchMock = require("fetch-mock");
 import { loadCredentialsFromFile } from "../lib/loadCredentialsFromFile";
 
@@ -65,11 +65,14 @@ describe("oauth-request-offline", function() {
 
     beforeEach(function() {
         fetchMock.config.overwriteRoutes = true;
-        fetchMock.post("https://account.api.here.com/oauth2/token", {
-            accessToken: mock_token,
-            tokenType: "bearer",
-            expiresIn: 3599
-        });
+        fetchMock.post(
+            "https://account.api.here.com/oauth2/token?" + SENT_WITH_PARAM,
+            {
+                accessToken: mock_token,
+                tokenType: "bearer",
+                expiresIn: 3599
+            }
+        );
     });
 
     afterEach(function() {
@@ -89,7 +92,7 @@ describe("oauth-request-offline", function() {
 
         const options: RequestInit & any = fetchMock.calls()[0][1];
         expect(options.headers.get("Authorization")).to.be.equal(
-            `OAuth oauth_consumer_key="mocked-key",oauth_nonce="mocked-nonce",oauth_signature_method="HMAC-SHA256",oauth_timestamp="1550777140",oauth_version="1.0",oauth_signature="67j%2FteHKLDlh%2F8VVMU3pRSyGN7lXtC49dkRtWCFoz6U%3D"`
+            `OAuth oauth_consumer_key="mocked-key",oauth_nonce="mocked-nonce",oauth_signature_method="HMAC-SHA256",oauth_timestamp="1550777140",oauth_version="1.0",oauth_signature="iC6P9BXdvvnJcaHmL5sskkz6R0ztFScyQfvvAujEmuo%3D"`
         );
     });
 
@@ -158,10 +161,14 @@ describe("oauth-request-offline", function() {
             tokenRequester: requestToken
         });
 
-        fetchMock.post("https://account.api.here.com/verify/accessToken", {
-            ok: true,
-            statusText: "valid"
-        });
+        fetchMock.post(
+            "https://account.api.here.com/verify/accessToken?" +
+                SENT_WITH_PARAM,
+            {
+                ok: true,
+                statusText: "valid"
+            }
+        );
 
         try {
             const reply = await userAuth.validateAccessToken(mock_token);
@@ -185,7 +192,8 @@ describe("oauth-request-offline", function() {
         const responseText = "Internal Server Error";
 
         fetchMock.post(
-            "https://account.api.here.com/verify/accessToken",
+            "https://account.api.here.com/verify/accessToken?" +
+                SENT_WITH_PARAM,
             responseStatus
         );
 
@@ -209,7 +217,7 @@ describe("oauth-request-offline", function() {
         const responseText = "Unauthorized";
 
         fetchMock.post(
-            "https://account.api.here.com/oauth2/token",
+            "https://account.api.here.com/oauth2/token?" + SENT_WITH_PARAM,
             responseStatus
         );
 
@@ -228,11 +236,14 @@ describe("oauth-request-lookupapi", function() {
 
     beforeEach(function() {
         fetchMock.config.overwriteRoutes = true;
-        fetchMock.post("https://account.api.here.com/oauth2/token", {
-            accessToken: mock_token,
-            tokenType: "bearer",
-            expiresIn: 3599
-        });
+        fetchMock.post(
+            "https://account.api.here.com/oauth2/token?" + SENT_WITH_PARAM,
+            {
+                accessToken: mock_token,
+                tokenType: "bearer",
+                expiresIn: 3599
+            }
+        );
     });
 
     afterEach(function() {
@@ -249,21 +260,24 @@ describe("oauth-request-lookupapi", function() {
             tokenRequester: requestToken
         });
 
-        fetchMock.get("https://account.api.here.com/user/me", {
-            userId: "userId",
-            realm: "realm",
-            firstname: "firstname",
-            lastname: "lastname",
-            email: "email",
-            dob: "dob",
-            language: "language",
-            countryCode: "countryCode",
-            emailVerified: true,
-            marketingEnabled: true,
-            createdTime: 1550777140,
-            updatedTime: 1550777141,
-            state: "state"
-        });
+        fetchMock.get(
+            "https://account.api.here.com/user/me?" + SENT_WITH_PARAM,
+            {
+                userId: "userId",
+                realm: "realm",
+                firstname: "firstname",
+                lastname: "lastname",
+                email: "email",
+                dob: "dob",
+                language: "language",
+                countryCode: "countryCode",
+                emailVerified: true,
+                marketingEnabled: true,
+                createdTime: 1550777140,
+                updatedTime: 1550777141,
+                state: "state"
+            }
+        );
 
         try {
             const reply = await userAuth.getUserInfo(mock_token);
@@ -297,21 +311,24 @@ describe("oauth-request-lookupapi", function() {
             tokenRequester: requestToken
         });
 
-        fetchMock.get("https://stg.account.api.here.com/user/me", {
-            userId: "userId",
-            realm: "realm",
-            firstname: "firstname",
-            lastname: "lastname",
-            email: "email",
-            dob: "dob",
-            language: "language",
-            countryCode: "countryCode",
-            emailVerified: true,
-            marketingEnabled: true,
-            createdTime: 1550777140,
-            updatedTime: 1550777141,
-            state: "state"
-        });
+        fetchMock.get(
+            "https://stg.account.api.here.com/user/me?" + SENT_WITH_PARAM,
+            {
+                userId: "userId",
+                realm: "realm",
+                firstname: "firstname",
+                lastname: "lastname",
+                email: "email",
+                dob: "dob",
+                language: "language",
+                countryCode: "countryCode",
+                emailVerified: true,
+                marketingEnabled: true,
+                createdTime: 1550777140,
+                updatedTime: 1550777141,
+                state: "state"
+            }
+        );
 
         try {
             const reply = await userAuth.getUserInfo(mock_token);
@@ -345,21 +362,25 @@ describe("oauth-request-lookupapi", function() {
             tokenRequester: requestToken
         });
 
-        fetchMock.get("https://elb.cn-northwest-1.account.hereapi.cn/user/me", {
-            userId: "userId",
-            realm: "realm",
-            firstname: "firstname",
-            lastname: "lastname",
-            email: "email",
-            dob: "dob",
-            language: "language",
-            countryCode: "countryCode",
-            emailVerified: true,
-            marketingEnabled: true,
-            createdTime: 1550777140,
-            updatedTime: 1550777141,
-            state: "state"
-        });
+        fetchMock.get(
+            "https://elb.cn-northwest-1.account.hereapi.cn/user/me?" +
+                SENT_WITH_PARAM,
+            {
+                userId: "userId",
+                realm: "realm",
+                firstname: "firstname",
+                lastname: "lastname",
+                email: "email",
+                dob: "dob",
+                language: "language",
+                countryCode: "countryCode",
+                emailVerified: true,
+                marketingEnabled: true,
+                createdTime: 1550777140,
+                updatedTime: 1550777141,
+                state: "state"
+            }
+        );
 
         try {
             const reply = await userAuth.getUserInfo(mock_token);
@@ -394,7 +415,8 @@ describe("oauth-request-lookupapi", function() {
         });
 
         fetchMock.get(
-            "https://elb.cn-northwest-1.account.sit.hereapi.cn/user/me",
+            "https://elb.cn-northwest-1.account.sit.hereapi.cn/user/me?" +
+                SENT_WITH_PARAM,
             {
                 userId: "userId",
                 realm: "realm",
@@ -444,7 +466,7 @@ describe("oauth-request-lookupapi", function() {
             tokenRequester: requestToken
         });
 
-        fetchMock.get("http://localhost/user/me", {
+        fetchMock.get("http://localhost/user/me?" + SENT_WITH_PARAM, {
             userId: "userId",
             realm: "realm",
             firstname: "firstname",
@@ -491,21 +513,24 @@ describe("oauth-request-lookupapi", function() {
             tokenRequester: requestToken
         });
 
-        fetchMock.get("https://account.api.here.com/user/me", {
-            userId: "userId",
-            realm: "realm",
-            firstname: "firstname",
-            lastname: "lastname",
-            email: "email",
-            dob: "dob",
-            language: "language",
-            countryCode: "countryCode",
-            emailVerified: true,
-            marketingEnabled: true,
-            createdTime: 1550777140,
-            updatedTime: 1550777141,
-            state: "state"
-        });
+        fetchMock.get(
+            "https://account.api.here.com/user/me?" + SENT_WITH_PARAM,
+            {
+                userId: "userId",
+                realm: "realm",
+                firstname: "firstname",
+                lastname: "lastname",
+                email: "email",
+                dob: "dob",
+                language: "language",
+                countryCode: "countryCode",
+                emailVerified: true,
+                marketingEnabled: true,
+                createdTime: 1550777140,
+                updatedTime: 1550777141,
+                state: "state"
+            }
+        );
 
         try {
             const reply = await userAuth.getUserInfo(mock_token);

--- a/@here/olp-sdk-authentication/test/requestTokenWeb.test.ts
+++ b/@here/olp-sdk-authentication/test/requestTokenWeb.test.ts
@@ -20,6 +20,7 @@
 import { assert } from "chai";
 import { requestToken } from "../index.web";
 
+import { SENT_WITH_PARAM } from "@here/olp-sdk-core/lib";
 import fetchMock = require("fetch-mock");
 
 const REPLY_TIMEOUT_MS = 600;
@@ -45,11 +46,14 @@ describe("oauth-request-offline", function() {
 
     beforeEach(function() {
         fetchMock.config.overwriteRoutes = true;
-        fetchMock.post("https://account.api.here.com/oauth2/token", {
-            accessToken: mock_token,
-            tokenType: "bearer",
-            expiresIn: 3599
-        });
+        fetchMock.post(
+            "https://account.api.here.com/oauth2/token?" + SENT_WITH_PARAM,
+            {
+                accessToken: mock_token,
+                tokenType: "bearer",
+                expiresIn: 3599
+            }
+        );
     });
 
     afterEach(function() {

--- a/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
+++ b/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
@@ -17,7 +17,12 @@
  * License-Filename: LICENSE
  */
 
-import { DownloadManager, HttpError, STATUS_CODES } from "@here/olp-sdk-core";
+import {
+    addSentWithParam,
+    DownloadManager,
+    HttpError,
+    STATUS_CODES
+} from "@here/olp-sdk-core";
 
 /** @internal
  * 'DeferredPromise' takes an executor function for executing it later, when [[exec]] is called.
@@ -92,7 +97,7 @@ export class DataStoreDownloadManager implements DownloadManager {
         init?: RequestInit
     ): Promise<Response> {
         try {
-            const response = await fetchFunction(url, init);
+            const response = await fetchFunction(addSentWithParam(url), init);
             if (
                 !this.requestShouldRetryOnError(response.status) ||
                 retryCount >= maxRetries

--- a/@here/olp-sdk-core/lib/utils/index.ts
+++ b/@here/olp-sdk-core/lib/utils/index.ts
@@ -43,3 +43,4 @@ export * from "./HttpError";
 export * from "./FetchOptions";
 export * from "./TileKey";
 export * from "./Uuid";
+export * from "./userAgent";

--- a/@here/olp-sdk-core/lib/utils/userAgent.ts
+++ b/@here/olp-sdk-core/lib/utils/userAgent.ts
@@ -17,4 +17,20 @@
  * License-Filename: LICENSE
  */
 
-export const LIB_VERSION = "1.6.0";
+import { LIB_VERSION } from "@here/olp-sdk-core/lib.version";
+
+/**
+ * The string for adding to the requests as query parameter.
+ */
+export const SENT_WITH_PARAM = `sentWith=OLP-TS-SDK-${LIB_VERSION}`;
+
+/**
+ * Adds sentWith param to the url.
+ * @param url the string, representing the url
+ * @returns the string, representing updated URL
+ */
+export function addSentWithParam(url: string): string {
+    return url.split("?").length === 1
+        ? `${url}?${SENT_WITH_PARAM}`
+        : `${url}&${SENT_WITH_PARAM}`;
+}

--- a/@here/olp-sdk-core/test/unit/DataStoreDownloadManager.test.ts
+++ b/@here/olp-sdk-core/test/unit/DataStoreDownloadManager.test.ts
@@ -20,7 +20,7 @@
 import sinon = require("sinon");
 import * as chai from "chai";
 import sinonChai = require("sinon-chai");
-import { DataStoreDownloadManager } from "@here/olp-sdk-core";
+import { DataStoreDownloadManager, SENT_WITH_PARAM } from "@here/olp-sdk-core";
 
 chai.use(sinonChai);
 const assert = chai.assert;
@@ -54,7 +54,9 @@ describe("DataStoreDownloadManager", function() {
 
         // Assert
         assert.isTrue(fetchStub.calledOnce);
-        assert.isTrue(fetchStub.getCall(0).args[0] === fakeDataUrl);
+        assert.isTrue(
+            fetchStub.getCall(0).args[0] === fakeDataUrl + "?" + SENT_WITH_PARAM
+        );
         assert.deepEqual(response.statusText, "success");
     });
 
@@ -77,7 +79,10 @@ describe("DataStoreDownloadManager", function() {
 
                 // callCount should be 4. (1 first call + 3 retries)
                 assert(fetchStub.callCount === 4);
-                assert(fetchStub.getCall(0).args[0] === fakeDataUrl);
+                assert(
+                    fetchStub.getCall(0).args[0] ===
+                        fakeDataUrl + "?" + SENT_WITH_PARAM
+                );
                 assert.equal(error.status, 503);
                 assert.equal(error.message, "Service unavailable!");
             });
@@ -102,7 +107,10 @@ describe("DataStoreDownloadManager", function() {
 
                 // callCount should be 4. (1 first call + 3 retries)
                 assert(fetchStub.callCount === 4);
-                assert(fetchStub.getCall(0).args[0] === fakeDataUrl);
+                assert(
+                    fetchStub.getCall(0).args[0] ===
+                        fakeDataUrl + "?" + SENT_WITH_PARAM
+                );
                 assert.equal(error.status, 500);
                 assert.equal(error.message, "Internal Server Error");
             });
@@ -127,7 +135,10 @@ describe("DataStoreDownloadManager", function() {
 
                 // callCount should be 4. (1 first call + 3 retries)
                 assert(fetchStub.callCount === 4);
-                assert(fetchStub.getCall(0).args[0] === fakeDataUrl);
+                assert(
+                    fetchStub.getCall(0).args[0] ===
+                        fakeDataUrl + "?" + SENT_WITH_PARAM
+                );
                 assert.equal(error.status, 429);
                 assert.equal(error.message, "To many requests");
             });
@@ -165,7 +176,7 @@ describe("DataStoreDownloadManager", function() {
         assert(fetchStub.callCount === CALLS_NUMBER);
         assert(
             fetchStub.getCall(MAX_PARALLEL_DOWNLOADS - 1).args[0] ===
-                fakeDataUrl
+                fakeDataUrl + "?" + SENT_WITH_PARAM
         );
     });
 

--- a/@here/olp-sdk-core/test/unit/userAgent.test.ts
+++ b/@here/olp-sdk-core/test/unit/userAgent.test.ts
@@ -17,4 +17,23 @@
  * License-Filename: LICENSE
  */
 
-export const LIB_VERSION = "1.6.0";
+import { assert } from "chai";
+import { addSentWithParam, SENT_WITH_PARAM } from "@here/olp-sdk-core";
+
+describe("addSentWithParam", function() {
+    it("Should be preparing string as an adding additional param", function() {
+        const url = "https://example.com/test/url?someParam=test";
+
+        const result = addSentWithParam(url);
+
+        assert.isTrue(result === url + "&" + SENT_WITH_PARAM);
+    });
+
+    it("Should be preparing string as an adding the first param", function() {
+        const url = "https://example.com/test/url";
+
+        const result = addSentWithParam(url);
+
+        assert.isTrue(result === url + "?" + SENT_WITH_PARAM);
+    });
+});

--- a/tests/integration/olp-sdk-dataservice-read/Handling-versions.test.ts
+++ b/tests/integration/olp-sdk-dataservice-read/Handling-versions.test.ts
@@ -33,6 +33,7 @@ import {
   CatalogVersionRequest
 } from "@here/olp-sdk-dataservice-read";
 import { FetchMock } from "../FetchMock";
+import { SENT_WITH_PARAM } from "@here/olp-sdk-core/lib";
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -128,7 +129,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(callsToApi.length).equals(2); // First to lookup api, second to the Query API.
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=0&" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -205,7 +207,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(callsToApi.length).equals(2); // First to lookup api, second to the Query API.
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/0/quadkeys/23605706/depths/0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/0/quadkeys/23605706/depths/0?" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -297,7 +300,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(callsToApi.length).equals(3); // 1 - lookup api, 1 - the Query API, 1 - blob API
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/0/quadkeys/23605706/depths/0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/0/quadkeys/23605706/depths/0?" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -376,7 +380,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(callsToApi.length).equals(3); // 1 - lookup api, 1 - the Query API, 1 - blob API
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=0&" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -440,7 +445,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(callsToApi.length).equals(2); // First to lookup api, second to the Query API.
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=142"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=142&" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -517,7 +523,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(callsToApi.length).equals(2); // First to lookup api, second to the Query API.
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/142/quadkeys/23605706/depths/0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/142/quadkeys/23605706/depths/0?" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -607,7 +614,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(callsToApi.length).equals(3); // 1 - lookup api, 1 - the Query API, 1 - blob API
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/142/quadkeys/23605706/depths/0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/142/quadkeys/23605706/depths/0?" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -686,7 +694,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(callsToApi.length).equals(3); // 1 - lookup api, 1 - the Query API, 1 - blob API
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=142"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=142&" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -766,7 +775,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(client["version"]).equals(0);
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=0&" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -859,7 +869,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(client["version"]).equals(0);
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/0/quadkeys/23605706/depths/0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/0/quadkeys/23605706/depths/0?" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -965,7 +976,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(client["version"]).equals(0);
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/0/quadkeys/23605706/depths/0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/versions/0/quadkeys/23605706/depths/0?" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -1060,7 +1072,8 @@ describe("Handling versions in the requests classes and clients", function() {
 
     expect(client["version"]).equals(0);
     expect(callToQueryApi.args[0]).equals(
-      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=0"
+      "https://query.data.api.platform.here.com/query/v1/layers/topology-geometry/partitions?partition=23605706&version=0&" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -1121,7 +1134,8 @@ describe("Handling versions in the requests classes and clients", function() {
     expect(callsToApi.length).equals(2); // 1 - lookup api, 1 - Metadata API
 
     expect(callToMetadataApi.args[0]).equals(
-      "https://metadata.data.api.platform.here.com/metadata/v1/layerVersions?version=0"
+      "https://metadata.data.api.platform.here.com/metadata/v1/layerVersions?version=0&" +
+        SENT_WITH_PARAM
     );
   });
 
@@ -1191,7 +1205,8 @@ describe("Handling versions in the requests classes and clients", function() {
     expect(callsToApi.length).equals(2); // 1 - lookup api, 1 - Metadata API
 
     expect(callToMetadataApi.args[0]).equals(
-      "https://metadata.data.api.platform.here.com/metadata/v1/versions?startVersion=-1&endVersion=0"
+      "https://metadata.data.api.platform.here.com/metadata/v1/versions?startVersion=-1&endVersion=0&" +
+        SENT_WITH_PARAM
     );
   });
 });


### PR DESCRIPTION
This CR adds the query parameter `sentWith`
for each request for tracking requests, made by SDK.

Resolves: OLPEDGE-2272

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>