### PR TITLE
Add Content-Encoding header to the PUT blob.

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/blob-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/blob-api.ts
@@ -560,6 +560,7 @@ export async function putBlob(
  * The value of this header must match the content type specified in the contentType field when the multipart
  * upload was initialized, and this content type must also match the content type specified in the layer's configuration.
  * For more information, see [RFC 7230, section 3.3.2: Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2).
+ * @param contentEncoding Optional param, can be `gzip` of `undefined`.
  * @param billingTag Billing Tag is an optional free-form tag which is used for grouping billing records together.
  * If supplied, it must be between 4 - 16 characters, contain only alpha/numeric ASCII characters [A-Za-z0-9].
  * Grouping billing records by billing tag will be available in future releases.
@@ -572,6 +573,7 @@ export async function putData(
         body: ArrayBuffer | Buffer;
         contentLength: number;
         contentType: string;
+        contentEncoding?: string;
         billingTag?: string;
     }
 ): Promise<Response> {
@@ -596,6 +598,9 @@ export async function putData(
     }
     if (params["contentLength"] !== undefined) {
         headers["Content-Length"] = params["contentLength"] as any;
+    }
+    if (params["contentEncoding"] !== undefined) {
+        headers["Content-Encoding"] = params["contentEncoding"];
     }
 
     return builder.requestBlob(urlBuilder, options);

--- a/@here/olp-sdk-dataservice-api/test/BlobApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/BlobApi.test.ts
@@ -284,7 +284,8 @@ describe("BlobApi", function() {
             billingTag: "mocked-billingTag",
             body: content,
             contentLength: 11,
-            contentType: "text/plain"
+            contentType: "text/plain",
+            contentEncoding: "mocked-contentEncoding"
         };
         const builder = {
             baseUrl: "http://mocked.url",
@@ -297,6 +298,9 @@ describe("BlobApi", function() {
                 // tslint:disable-next-line: no-magic-numbers
                 expect(options.headers["Content-Length"]).equals(11);
                 expect(options.headers["Content-Type"]).equals("text/plain");
+                expect(options.headers["Content-Encoding"]).equals(
+                    "mocked-contentEncoding"
+                );
                 return Promise.resolve("success");
             }
         };

--- a/@here/olp-sdk-dataservice-write/lib/client/VersionedLayerClient.ts
+++ b/@here/olp-sdk-dataservice-write/lib/client/VersionedLayerClient.ts
@@ -66,16 +66,16 @@ export class VersionedLayerClient {
 
     /**
      * Checks whether the data handle is not used.
-     * 
+     *
      * Data handles must be unique within a layer across all versions.
-     * If the data handle exists, generate a new one and check it again 
+     * If the data handle exists, generate a new one and check it again
      * to be sure that it is not present in the blob store.
-     * 
+     *
      * @param request `CheckDataExistsRequest` with the required params.
      * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     * 
+     *
      * @returns The `Promise` void if the data handle exists.
      * If the data handle does not exist, rejects with an HTTP response (404 status) or an HTTP error.
      */
@@ -166,7 +166,7 @@ export class VersionedLayerClient {
 
     /**
      * Starts a new publication.
-     * 
+     *
      * Determines the publication type based on the provided layer IDs.
      * A publication can only consist of layer IDs that have the same layer type.
      * For example, you can have a publication for multiple versioned layers,
@@ -219,12 +219,12 @@ export class VersionedLayerClient {
 
     /**
      * Uploads one partition blob and metadata at once.
-     * 
+     *
      * @param request The `PublishSinglePartitionRequest` object with the needed parameters.
      * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     * 
+     *
      * @returns The `Promise` resolves if the operation was successful; rejects otherwise.
      */
     public async publishToBatch(
@@ -328,7 +328,7 @@ export class VersionedLayerClient {
 
     /**
      * Cancels the publication if it has not been submitted.
-     * 
+     *
      * Fails if you attempt to cancel a submitted publication.
      * This allows the specified publication to be abandoned.
      *
@@ -336,7 +336,7 @@ export class VersionedLayerClient {
      * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     * 
+     *
      * @returns True if the operation was successful; rejects with an error otherwise.
      */
     public async cancelBatch(
@@ -379,7 +379,7 @@ export class VersionedLayerClient {
      * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     * 
+     *
      * @returns The publication details.
      */
     public async getBatch(
@@ -417,7 +417,7 @@ export class VersionedLayerClient {
 
     /**
      * Submits the publication (that is a batch) and initiates post-processing if necessary.
-     * 
+     *
      * You cannot modify or interrupt the publication process, so double-check the publication details before submitting it.
      *
      * The publication state becomes `Submitted` directly after submission and `Succeeded` after successful processing.
@@ -432,7 +432,7 @@ export class VersionedLayerClient {
      * @param abortSignal The signal object that allows you to communicate with the request
      * and, if required, abort it using the `AbortController` object.
      * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-     * 
+     *
      * @returns The `Promise` resolves if the operation was successful; rejects otherwise.
      */
     public async completeBatch(
@@ -600,7 +600,8 @@ export class VersionedLayerClient {
                 body: data,
                 contentType,
                 dataHandle,
-                contentLength: dataSize
+                contentLength: dataSize,
+                contentEncoding: request.getContentEncoding()
             });
         }
 

--- a/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
@@ -494,6 +494,41 @@ describe("VersionedLayerClient write", function() {
         expect(response2.getDataHandle()).equals(mockedDatahandle);
     });
 
+    it("UploadBlob with content encoding gzip", async function() {
+        const data = Buffer.alloc(25);
+        const mockedDatahandle = "mocked-datahandle";
+        const mockedContentType = "text/plain";
+        const mockedBillingTag = "mocked-billing-tag";
+        const mockedContentEncoding = "mocked-contentEncoding";
+
+        const client = new VersionedLayerClient({
+            catalogHrn,
+            settings
+        });
+
+        const layerId = "mocked-layer";
+
+        putDataStub.callsFake(() =>
+            Promise.resolve({
+                status: 204
+            })
+        );
+
+        const request = new UploadBlobRequest()
+            .withLayerId(layerId)
+            .withData(data)
+            .withDataHandle(mockedDatahandle)
+            .withContentType(mockedContentType)
+            .withBillingTag(mockedBillingTag)
+            .withContentEncoding(mockedContentEncoding);
+
+        const response = await client.uploadBlob(request);
+        expect(response.getDataHandle()).equals(mockedDatahandle);
+        expect(putDataStub.args[0][1].contentEncoding).equals(
+            mockedContentEncoding
+        );
+    });
+
     it("UploadBlob should generate and return the datahandle", async function() {
         const data = Buffer.alloc(25000);
         const mockedDatahandle = "mocked-datahandle";


### PR DESCRIPTION
This CR adds the Content-Encoding header to the PUT blob request
if user pass request.withContentEncoding("some-string")
to the uploading method.

Resolves: OLPSUP-11688

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>