### PR TITLE
Add post release check to publish job on Travis

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,22 +86,6 @@ regression_generate_report_job:
       - master
       - branches
 
-release_verify_job:
-  stage: test
-  tags:
-  - docker-prod
-  image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE_PERFORMANCE}:${DOCKER_IMAGE_PERFORMANCE_VERSION}
-  script:
-  - npm install -g yarn
-  - yarn
-  - yarn bootstrap
-  - npm run build
-  - npm run http-server-testing-bundles & npm run test-published-bundles
-  when: manual
-  only:
-    - master
-    - branches
-
 weekly_security_test_job:
   stage: test
   tags:

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -55,4 +55,12 @@ while [[ $# -gt 0 ]]; do
     # Shift after checking all the cases to get the next option
     shift
 done
-echo 'Publish done!'
+echo 'Publish done! To be verified in 1m. ...'
+sleep 60
+
+echo 'Publish verification...'
+yarn
+yarn bootstrap
+npm run build
+npm run http-server-testing-bundles & npm run test-published-bundles
+echo 'Publish verification done! '


### PR DESCRIPTION
Migrated this job from Gitlab due to lack of chrome-headless
on our Gitlab images.

Resolves: OLPEDGE-2321

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>