### PR TITLE
Deprecate using version from request class.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/cache/MetadataCacheRepository.ts
+++ b/@here/olp-sdk-dataservice-read/lib/cache/MetadataCacheRepository.ts
@@ -34,6 +34,7 @@ export class MetadataCacheRepository {
     constructor(private readonly cache: KeyValueCache) {}
 
     /**
+     * @deprecated This signature will be removed by 04.2021. Please set the version as the last argument.
      * Stores a key-value pair in the cache.
      *
      * @return True if the operation is successful, false otherwise.
@@ -43,6 +44,27 @@ export class MetadataCacheRepository {
         hrn: string,
         layerId: string,
         partitions: MetadataApi.Partition[]
+    ): boolean;
+
+    /**
+     * Stores a key-value pair in the cache.
+     *
+     * @return True if the operation is successful, false otherwise.
+     */
+    public put(
+        rq: PartitionsRequest,
+        hrn: string,
+        layerId: string,
+        partitions: MetadataApi.Partition[],
+        // tslint:disable-next-line: unified-signatures
+        version?: number
+    ): boolean;
+    public put(
+        rq: PartitionsRequest,
+        hrn: string,
+        layerId: string,
+        partitions: MetadataApi.Partition[],
+        version?: number
     ): boolean {
         const partitionsIds = rq.getPartitionIds();
         let key: string;
@@ -51,7 +73,7 @@ export class MetadataCacheRepository {
                 key = this.createKey({
                     hrn,
                     layerId,
-                    version: rq.getVersion(),
+                    version: version !== undefined ? version : rq.getVersion(),
                     partitionId: metadata.partition
                 });
                 this.cache.put(key, JSON.stringify(metadata));
@@ -63,10 +85,24 @@ export class MetadataCacheRepository {
         key = this.createKey({
             hrn,
             layerId,
-            version: rq.getVersion()
+            version: version !== undefined ? version : rq.getVersion()
         });
         return this.cache.put(key, JSON.stringify(partitions));
     }
+
+    /**
+     * @deprecated This signature will be removed by 04.2021. Please set the version as the last argument.
+     * Gets a metadata from the cache.
+     *
+     * @param service The name of the API service for which you want to get the base URL.
+     * @param serviceVersion The service version.
+     * @return The base URL of the service, or undefined if the base URL does not exist.
+     */
+    public get(
+        rq: PartitionsRequest,
+        hrn: string,
+        layerId: string
+    ): MetadataApi.Partition[] | undefined;
 
     /**
      * Gets a metadata from the cache.
@@ -78,7 +114,15 @@ export class MetadataCacheRepository {
     public get(
         rq: PartitionsRequest,
         hrn: string,
-        layerId: string
+        layerId: string,
+        // tslint:disable-next-line: unified-signatures
+        version?: number
+    ): MetadataApi.Partition[] | undefined;
+    public get(
+        rq: PartitionsRequest,
+        hrn: string,
+        layerId: string,
+        version?: number
     ): MetadataApi.Partition[] | undefined {
         const partitionsIds = rq.getPartitionIds();
         let key: string;
@@ -88,7 +132,7 @@ export class MetadataCacheRepository {
                 key = this.createKey({
                     hrn,
                     layerId,
-                    version: rq.getVersion(),
+                    version: version !== undefined ? version : rq.getVersion(),
                     partitionId
                 });
 
@@ -119,7 +163,7 @@ export class MetadataCacheRepository {
         key = this.createKey({
             hrn,
             layerId,
-            version: rq.getVersion()
+            version: version !== undefined ? version : rq.getVersion()
         });
 
         const serializedPartitions = this.cache.get(key);

--- a/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/PartitionsRequest.ts
@@ -35,7 +35,7 @@ export class PartitionsRequest {
     private fetchOption = FetchOptions.OnlineIfNotFound;
 
     /**
-     * This method is deprecated and is not used. If you need to set the version,
+     * This method is @deprecated and will be removed by 04.2021. If you need to set the version,
      * initialize the version client with the new constructor. Otherwise, the latest version will be used.
      *
      * Gets a layer version for the request.
@@ -47,7 +47,7 @@ export class PartitionsRequest {
     }
 
     /**
-     * This method is deprecated and is not used. If you need to set the version,
+     * This method is @deprecated and will be removed by 04.2021. If you need to set the version,
      * initialize the version client with the new constructor. Otherwise, the latest version will be used.
      *
      * An optional method that sets the provided layer version.

--- a/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
@@ -153,6 +153,7 @@ export class QueryClient {
     }
 
     /**
+     * @deprecated This signature will be removed by 04.2021. Please set the version as the last argument.
      * Gets partitions using their IDs.
      *
      * @param request The `PartitionsRequest` instance.
@@ -170,9 +171,41 @@ export class QueryClient {
         layerId: string,
         hrn: HRN,
         abortSignal?: AbortSignal
+    ): Promise<QueryApi.Partitions>;
+
+    /**
+     * Gets partitions using their IDs.
+     *
+     * @param request The `PartitionsRequest` instance.
+     * @param layerId The ID of the layer from which you want to get partitions.
+     * @param hrn The HERE Resource Name (HRN) of the layer.
+     * @param abortSignal A signal object that allows you to communicate with a request (such as the `fetch` request)
+     * and, if required, abort it using the `AbortController` object.
+     *
+     * For more information, see the [`AbortController` documentation](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+     *
+     * @return The requested partitions.
+     */
+    public async getPartitionsById(
+        request: PartitionsRequest,
+        layerId: string,
+        hrn: HRN,
+        abortSignal?: AbortSignal,
+        // tslint:disable-next-line: unified-signatures
+        version?: number
+    ): Promise<QueryApi.Partitions>;
+    public async getPartitionsById(
+        request: PartitionsRequest,
+        layerId: string,
+        hrn: HRN,
+        abortSignal?: AbortSignal,
+        catalogVersion?: number
     ): Promise<QueryApi.Partitions> {
         const idsList = request.getPartitionIds();
-        const version = request.getVersion();
+        const version =
+            catalogVersion !== undefined
+                ? catalogVersion
+                : request.getVersion();
 
         if (!idsList) {
             return Promise.reject("Please provide correct partitionIds list");


### PR DESCRIPTION
This CR deprecates the using version from request class.
The methods `WithVersion` and `GetVersion` are deprecated in the
class `PartitionsRequest`, so we should not use that.

Relates-to: OLPEDGE-2351

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>