### PR TITLE
Fix bug after removed deprecates.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
@@ -216,7 +216,8 @@ export class QueryClient {
             const cachedPartitions = cache.get(
                 request,
                 hrn.toString(),
-                layerId
+                layerId,
+                version
             );
 
             if (cachedPartitions) {
@@ -262,7 +263,7 @@ export class QueryClient {
                     version: partition.version
                 })
             );
-            cache.put(request, hrn.toString(), layerId, partitions);
+            cache.put(request, hrn.toString(), layerId, partitions, version);
         }
 
         return Promise.resolve(medatada);


### PR DESCRIPTION
This CR fixes bug with caching for versioned partitions metadata.
The keys created for the cache was incorect. Version was missed.

Resolve: OLPEDGE-2358
Relates-To: OLPEDGE-2351

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>