### PR TITLE
Update CHANGELOG and versions.

### DIFF
--- a/@here/olp-sdk-authentication/package.json
+++ b/@here/olp-sdk-authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-authentication",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Wrapper around the HERE Authentication and Authorization REST API obtaining short-lived access tokens that are used to authenticate requests to HERE services.",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,9 +49,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "^1.1.0",
+    "@here/olp-sdk-core": "^1.2.0",
     "@types/properties-reader": "^0.0.1",
-    "@here/olp-sdk-fetch": "^1.6.0",
+    "@here/olp-sdk-fetch": "^1.7.0",
     "properties-reader": "^0.3.1"
   },
   "devDependencies": {

--- a/@here/olp-sdk-authentication/test/OAuth.test.ts
+++ b/@here/olp-sdk-authentication/test/OAuth.test.ts
@@ -92,7 +92,7 @@ describe("oauth-request-offline", function() {
 
         const options: RequestInit & any = fetchMock.calls()[0][1];
         expect(options.headers.get("Authorization")).to.be.equal(
-            `OAuth oauth_consumer_key="mocked-key",oauth_nonce="mocked-nonce",oauth_signature_method="HMAC-SHA256",oauth_timestamp="1550777140",oauth_version="1.0",oauth_signature="iC6P9BXdvvnJcaHmL5sskkz6R0ztFScyQfvvAujEmuo%3D"`
+            `OAuth oauth_consumer_key="mocked-key",oauth_nonce="mocked-nonce",oauth_signature_method="HMAC-SHA256",oauth_timestamp="1550777140",oauth_version="1.0",oauth_signature="ShzC6ULa9P52tbrEJFPwktjnqyxm%2FMEYzeL0HaxJSx8%3D"`
         );
     });
 

--- a/@here/olp-sdk-core/lib.version.ts
+++ b/@here/olp-sdk-core/lib.version.ts
@@ -17,4 +17,4 @@
  * License-Filename: LICENSE
  */
 
-export const LIB_VERSION = "1.6.0";
+export const LIB_VERSION = "1.7.0";

--- a/@here/olp-sdk-core/package.json
+++ b/@here/olp-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Core features of the HERE Data Platform",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,8 +49,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-fetch": "^1.6.0",
-    "@here/olp-sdk-dataservice-api": "^1.6.0"
+    "@here/olp-sdk-fetch": "^1.7.0",
+    "@here/olp-sdk-dataservice-api": "^1.7.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/@here/olp-sdk-dataservice-api/package.json
+++ b/@here/olp-sdk-dataservice-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-api",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Generated from the OpenAPI specification of the HERE Open Location Platform Data API",
   "main": "index.js",
   "typings": "index",

--- a/@here/olp-sdk-dataservice-read/lib/cache/MetadataCacheRepository.ts
+++ b/@here/olp-sdk-dataservice-read/lib/cache/MetadataCacheRepository.ts
@@ -34,7 +34,7 @@ export class MetadataCacheRepository {
     constructor(private readonly cache: KeyValueCache) {}
 
     /**
-     * @deprecated This signature will be removed by 04.2021. Please set the version as the last argument.
+     * @deprecated This signature will be removed by 05.2021. Please set the version as the last argument.
      * Stores a key-value pair in the cache.
      *
      * @return True if the operation is successful, false otherwise.
@@ -91,7 +91,7 @@ export class MetadataCacheRepository {
     }
 
     /**
-     * @deprecated This signature will be removed by 04.2021. Please set the version as the last argument.
+     * @deprecated This signature will be removed by 05.2021. Please set the version as the last argument.
      * Gets a metadata from the cache.
      *
      * @param service The name of the API service for which you want to get the base URL.

--- a/@here/olp-sdk-dataservice-read/package.json
+++ b/@here/olp-sdk-dataservice-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-read",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Wrapper around a subset of the HERE Open Location Platform Data REST API related to reading data from OLP catalogs",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,9 +49,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "^1.1.0",
-    "@here/olp-sdk-dataservice-api": "^1.6.0",
-    "@here/olp-sdk-fetch": "^1.6.0"
+    "@here/olp-sdk-core": "^1.2.0",
+    "@here/olp-sdk-dataservice-api": "^1.7.0",
+    "@here/olp-sdk-fetch": "^1.7.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/@here/olp-sdk-dataservice-write/package.json
+++ b/@here/olp-sdk-dataservice-write/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-write",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Wrapper around a subset of the HERE Open Location Platform Data REST API related to writing data to OLP catalogs",
   "main": "index.js",
   "browser": "index.web.js",
@@ -50,9 +50,9 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "^1.1.0",
-    "@here/olp-sdk-dataservice-api": "^1.6.0",
-    "@here/olp-sdk-fetch": "^1.6.0"
+    "@here/olp-sdk-core": "^1.2.0",
+    "@here/olp-sdk-dataservice-api": "^1.7.0",
+    "@here/olp-sdk-fetch": "^1.7.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/@here/olp-sdk-fetch/package.json
+++ b/@here/olp-sdk-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-fetch",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Adds a subset of the fetch API for Node.js",
   "main": "index.js",
   "browser": "index.web.js",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## v1.7.0 (02/11/2020)
+
+**olp-sdk-core**
+
+- Added the `sentWith` query parameter to each request.
+- Updated dependencies.
+
+**olp-sdk-authentication**
+
+- Added the `sentWith` query parameter to each request.
+- Updated dependencies.
+
+**olp-sdk-fetch**
+
+- Updated dependencies.
+
+**olp-sdk-dataservice-api**
+
+- Added generated functions and interfaces that support Authorization APIs. You can find them at `@here/olp-sdk-dataservice-api/lib/authorization-api-v1.1.ts`.
+- Added the `Content-Encoding` header to the PUT blob request. Without this header, it was not possible to upload gzipped blobs.
+- **Breaking change** Removed deprecated items that have exceeded the six-month deprecation period. @see [#385](https://github.com/heremaps/here-data-sdk-typescript/pull/385).
+- Updated dependencies.
+
+**olp-sdk-dataservice-read**
+
+- Now, using a version in the `MetadataCacheRepository` request class is deprecated and will be removed by 05.2021.
+- Updated dependencies.
+- **Breaking change** Removed deprecated items that have exceeded the six-month deprecation period. @see [#385](https://github.com/heremaps/here-data-sdk-typescript/pull/385).
+
+**olp-sdk-dataservice-write**
+
+- Updated dependencies.
+
 ## v1.6.0 (21/09/2020)
 
 **olp-sdk-core**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-ts",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "HERE OLP SDK for TypeScript",
   "author": {
     "name": "HERE Europe B.V.",


### PR DESCRIPTION
This is a release commit before creating release tag.
The test in authentication updated according to the new hash, based
on the query string with `sentWith` param with updated version.

Resolves: OLPEDGE-2365

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>