### PR TITLE
Review the README file (example) and update links

### DIFF
--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -26,7 +26,7 @@ For more details, see the [HERE Data User Guide](https://developer.here.com/olp/
 
 To work with catalog or service requests to the HERE platform, you need to get authentication and authorization credentials.
 
-You can authenticate to the HERE platform within your application with the platform credentials available on the HERE portal by means of the Data SDK for TypeScript authentication library. For instructions on how to get credentials, see the [related section](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) in the Terms and Permissions User Guide.
+You can authenticate to the HERE platform within your application with the platform credentials available on the HERE portal by means of the Data SDK for TypeScript authentication library. For the available authentication options, see the [Identity & Access Management Developer Guide](https://developer.here.com/documentation/identity-access-management/dev_guide/index.html).
 
 After you set up the credentials, you can use them to access the HERE Data SDK libraries.
 

--- a/docs/examples/authenticate.md
+++ b/docs/examples/authenticate.md
@@ -8,11 +8,11 @@ You can use an access token to authenticate to the HERE platform and start worki
 
 1. Create your application and get your API key.
 
-   For instructions, see the [Manage Apps](https://developer.here.com/documentation/access-control/user_guide/topics/manage-apps.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Manage Apps](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/manage-apps.html) section in the Identity & Access Management Developer Guide.
 
 2. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 

--- a/docs/examples/here-data-sdk-example/README.md
+++ b/docs/examples/here-data-sdk-example/README.md
@@ -1,44 +1,40 @@
-# Getting Started with React App and Here Data SDK for Typescript.
+# Getting Started with the React App and Here Data SDK for Typescript
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-## Run
+## Run the App
 
-1) Copy ./public/credentials.json.sample to ./public/credentials.json and add your credentials to that file. [See more](https://developer.here.com/documentation/sdk-typescript/dev_guide/topics/authenticate.html).
+1. Copy `./public/credentials.json.sample` to `./public/credentials.json`, and then add your credentials to that file.
+    
+    For more information, see the [related section](https://developer.here.com/documentation/sdk-typescript/dev_guide/topics/authenticate.html) in our Developer Guide.
 
-2) Run `yarn` to fetch dependencies.
+2. To fetch dependencies, run `yarn`.
 
-3) Run `yarn start` to run app in development mode.
+3. To run the app in the development mode, run `yarn start`.
 
-4) Open in your favorite browser `http://localhost:3000`.
+4. In your favorite browser, open `http://localhost:3000`.
 
 ## Available Scripts
 
-In the project directory, you can run:
+In the project directory, you can run the following scripts:
 
-### `yarn start`
+- `yarn start` – runs the app in the development mode.\
+    To view it in the browser, open [http://localhost:3000](http://localhost:3000).
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+    The page reloads if you make edits.\
+    You will also see no lint errors in the console.
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+- `yarn build` – builds the app for production in the `build` folder.\
+    It correctly bundles React in the production mode and optimizes the build for the best performance.
 
-### `yarn build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+    The build is minified, and the filenames include hashes.\
+    Your app is ready to be deployed. For more information on deployment, see the [related section](https://facebook.github.io/create-react-app/docs/deployment) in the Create React App documentation.
 
 ## Learn More
 
-For more information on Data API, see its <a href="https://developer.here.com/olp/documentation/data-api/data_dev_guide/index.html" target="_blank">Developer Guide</a> and <a href="https://developer.here.com/olp/documentation/data-api/api-reference.html" target="_blank">API Reference</a>.
+For more information, see the following documentation:
 
+- Data API <a href="https://developer.here.com/olp/documentation/data-api/data_dev_guide/index.html" target="_blank">Developer Guide</a> and <a href="https://developer.here.com/olp/documentation/data-api/api-reference.html" target="_blank">API Reference</a>
+- [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started)
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+- [React documentation](https://reactjs.org/)

--- a/docs/examples/nodejs-read-index-layer.md
+++ b/docs/examples/nodejs-read-index-layer.md
@@ -71,7 +71,7 @@ To authenticate with the HERE platform, you must get platform credentials that c
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 

--- a/docs/examples/nodejs-read-stream-layer.md
+++ b/docs/examples/nodejs-read-stream-layer.md
@@ -71,7 +71,7 @@ To authenticate with the HERE platform, you must get platform credentials that c
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 

--- a/docs/examples/nodejs-read-versioned-layer.md
+++ b/docs/examples/nodejs-read-versioned-layer.md
@@ -71,7 +71,7 @@ To authenticate with the Here platform, you must get platform credentials that c
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 

--- a/docs/examples/nodejs-read-volatile-layer.md
+++ b/docs/examples/nodejs-read-volatile-layer.md
@@ -71,7 +71,7 @@ To authenticate with the HERE platform, you must get platform credentials that c
 
 1. Get your platform credentials.
 
-   For instructions, see the [Get Credentials](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html) section in the Terms and Permissions User Guide.
+   For instructions, see the [Register Your Application](https://developer.here.com/documentation/identity-access-management/dev_guide/topics/plat-token.html#step-1-register-your-application) section in the Identity & Access Management Developer Guide.
 
    You get the `credentials.properties` file.
 


### PR DESCRIPTION
- Review the following file:
docs/examples/here-data-sdk-example/README.md
- As the Teams and Permissions guide will be deleted, and
the Identity & Access Management Developer Guide will be used instead,
update the links.

Relates-to: OLPEDGE-2362, OLPEDGE-2366

Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>