### PR TITLE
Change webpack configuration for bundling.

### DIFF
--- a/@here/olp-sdk-authentication/package.json
+++ b/@here/olp-sdk-authentication/package.json
@@ -50,18 +50,17 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@here/olp-sdk-core": "^1.2.0",
-    "@types/properties-reader": "^0.0.1",
     "@here/olp-sdk-fetch": "^1.7.0",
     "properties-reader": "^0.3.1"
   },
   "devDependencies": {
+    "@types/properties-reader": "^0.0.1",
     "@types/chai": "^4.2.7",
     "@types/fetch-mock": "^7.3.2",
     "@types/mocha": "^5.2.7",
     "@types/node": "^14.11.8",
     "@types/sinon-chai": "^3.2.3",
     "@types/sinon": "7.0.3",
-    "awesome-typescript-loader": "^5.2.1",
     "chai": "^4.2.0",
     "fetch-mock": "^8.3.1",
     "husky": "^3.1.0",

--- a/@here/olp-sdk-authentication/webpack.config.js
+++ b/@here/olp-sdk-authentication/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const packageInfo = require('./package.json');
 
 
 module.exports = env => {
@@ -10,26 +9,14 @@ module.exports = env => {
     target: "web",
     devtool: isProd ? undefined : "inline-source-map",
     resolve: {
-      extensions: [".ts", ".js"]
+      extensions: [".js"]
     },
-    entry: "./index.web.ts",
+    entry: "./index.web.js",
     output: {
       filename: `bundle.umd${isProd ? '.min' : '.dev'}.js`,
       path: path.resolve(__dirname),
       libraryTarget: "umd",
       globalObject: 'this'
-    },
-    module: {
-      rules: [
-        {
-          test: /\.tsx?$/,
-          loader: "awesome-typescript-loader",
-          exclude: /node_modules/,
-          options: {
-              onlyCompileBundledFiles: true
-          }
-        }
-      ]
     }
   };
 };

--- a/@here/olp-sdk-core/package.json
+++ b/@here/olp-sdk-core/package.json
@@ -58,7 +58,6 @@
     "@types/node": "^14.11.8",
     "@types/sinon": "7.0.3",
     "@types/sinon-chai": "^3.2.3",
-    "awesome-typescript-loader": "^5.2.1",
     "chai": "^4.2.0",
     "glob": "^7.1.6",
     "husky": "^3.1.0",

--- a/@here/olp-sdk-core/webpack.config.js
+++ b/@here/olp-sdk-core/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const packageInfo = require('./package.json');
 
 module.exports = env => {
   const isProd = env.NODE_ENV === "production";
@@ -9,26 +8,14 @@ module.exports = env => {
     mode: env.NODE_ENV,
     devtool: isProd ? undefined : "inline-source-map",
     resolve: {
-      extensions: [".ts", ".js"]
+      extensions: [".js"]
     },
-    entry: "./index.web.ts",
+    entry: "./index.web.js",
     output: {
       filename: `bundle.umd${isProd ? '.min' : '.dev'}.js`,
       path: path.resolve(__dirname),
       libraryTarget: "umd",
       globalObject: 'this'
-    },
-    module: {
-      rules: [
-        {
-          test: /\.tsx?$/,
-          loader: "awesome-typescript-loader",
-          exclude: /node_modules/,
-          options: {
-              onlyCompileBundledFiles: true
-          }
-        }
-      ]
     }
   };
 };

--- a/@here/olp-sdk-dataservice-api/package.json
+++ b/@here/olp-sdk-dataservice-api/package.json
@@ -53,7 +53,6 @@
     "@types/mocha": "^5.2.7",
     "@types/sinon-chai": "^3.2.3",
     "@types/sinon": "7.0.3",
-    "awesome-typescript-loader": "^5.2.1",
     "chai": "^4.2.0",
     "husky": "^3.1.0",
     "lint-staged": "^9.5.0",

--- a/@here/olp-sdk-dataservice-api/webpack.config.js
+++ b/@here/olp-sdk-dataservice-api/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const packageInfo = require('./package.json');
 
 module.exports = env => {
   const isProd = env.NODE_ENV === "production";
@@ -9,26 +8,14 @@ module.exports = env => {
     mode: env.NODE_ENV,
     devtool: isProd ? undefined : "inline-source-map",
     resolve: {
-      extensions: [".ts", ".js"]
+      extensions: [".js"]
     },
-    entry: "./index.ts",
+    entry: "./index.js",
     output: {
       filename: `bundle.umd${isProd ? '.min' : '.dev'}.js`,
       path: path.resolve(__dirname),
       libraryTarget: "umd",
       globalObject: 'this'
-    },
-    module: {
-      rules: [
-        {
-          test: /\.tsx?$/,
-          loader: "awesome-typescript-loader",
-          exclude: /node_modules/,
-          options: {
-              onlyCompileBundledFiles: true
-          }
-        }
-      ]
     }
   };
 };

--- a/@here/olp-sdk-dataservice-read/package.json
+++ b/@here/olp-sdk-dataservice-read/package.json
@@ -59,7 +59,6 @@
     "@types/node": "^14.11.8",
     "@types/sinon": "7.0.3",
     "@types/sinon-chai": "^3.2.3",
-    "awesome-typescript-loader": "^5.2.1",
     "chai": "^4.2.0",
     "glob": "^7.1.6",
     "husky": "^3.1.0",

--- a/@here/olp-sdk-dataservice-read/webpack.config.js
+++ b/@here/olp-sdk-dataservice-read/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const packageInfo = require('./package.json');
 
 module.exports = env => {
   const isProd = env.NODE_ENV === "production";
@@ -9,26 +8,14 @@ module.exports = env => {
     mode: env.NODE_ENV,
     devtool: isProd ? undefined : "inline-source-map",
     resolve: {
-      extensions: [".ts", ".js"]
+      extensions: [".js"]
     },
-    entry: "./index.web.ts",
+    entry: "./index.web.js",
     output: {
       filename: `bundle.umd${isProd ? '.min' : '.dev'}.js`,
       path: path.resolve(__dirname),
       libraryTarget: "umd",
       globalObject: 'this'
-    },
-    module: {
-      rules: [
-        {
-          test: /\.tsx?$/,
-          loader: "awesome-typescript-loader",
-          exclude: /node_modules/,
-          options: {
-              onlyCompileBundledFiles: true
-          }
-        }
-      ]
     }
   };
 };

--- a/@here/olp-sdk-dataservice-write/package.json
+++ b/@here/olp-sdk-dataservice-write/package.json
@@ -60,7 +60,6 @@
     "@types/node": "^14.11.8",
     "@types/sinon": "7.0.3",
     "@types/sinon-chai": "^3.2.3",
-    "awesome-typescript-loader": "^5.2.1",
     "chai": "^4.2.0",
     "glob": "^7.1.6",
     "husky": "^3.1.0",

--- a/@here/olp-sdk-dataservice-write/webpack.config.js
+++ b/@here/olp-sdk-dataservice-write/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const packageInfo = require('./package.json');
 
 module.exports = env => {
   const isProd = env.NODE_ENV === "production";
@@ -9,26 +8,14 @@ module.exports = env => {
     mode: env.NODE_ENV,
     devtool: isProd ? undefined : "inline-source-map",
     resolve: {
-      extensions: [".ts", ".js"]
+      extensions: [".js"]
     },
-    entry: "./index.web.ts",
+    entry: "./index.web.js",
     output: {
       filename: `bundle.umd${isProd ? '.min' : '.dev'}.js`,
       path: path.resolve(__dirname),
       libraryTarget: "umd",
       globalObject: 'this'
-    },
-    module: {
-      rules: [
-        {
-          test: /\.tsx?$/,
-          loader: "awesome-typescript-loader",
-          exclude: /node_modules/,
-          options: {
-              onlyCompileBundledFiles: true
-          }
-        }
-      ]
     }
   };
 };

--- a/@here/olp-sdk-fetch/package.json
+++ b/@here/olp-sdk-fetch/package.json
@@ -56,7 +56,6 @@
     "@types/node": "^14.11.8",
     "@types/sinon": "7.0.3",
     "@types/sinon-chai": "^3.2.3",
-    "awesome-typescript-loader": "^5.2.1",
     "chai": "^4.2.0",
     "glob": "^7.1.6",
     "husky": "^3.1.0",

--- a/@here/olp-sdk-fetch/webpack.config.js
+++ b/@here/olp-sdk-fetch/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const packageInfo = require('./package.json');
 
 module.exports = env => {
   const isProd = env.NODE_ENV === "production";
@@ -9,26 +8,14 @@ module.exports = env => {
     mode: env.NODE_ENV,
     devtool: isProd ? undefined : "inline-source-map",
     resolve: {
-      extensions: [".ts", ".js"]
+      extensions: [".js"]
     },
-    entry: "./index.web.ts",
+    entry: "./index.web.js",
     output: {
       filename: `bundle.umd${isProd ? '.min' : '.dev'}.js`,
       path: path.resolve(__dirname),
       libraryTarget: "umd",
       globalObject: 'this'
-    },
-    module: {
-      rules: [
-        {
-          test: /\.tsx?$/,
-          loader: "awesome-typescript-loader",
-          exclude: /node_modules/,
-          options: {
-              onlyCompileBundledFiles: true
-          }
-        }
-      ]
     }
   };
 };

--- a/docs/examples/ts/package.json
+++ b/docs/examples/ts/package.json
@@ -18,7 +18,6 @@
     "@here/olp-sdk-dataservice-read": "1.3.1"
   },
   "devDependencies": {
-    "awesome-typescript-loader": "^5.2.1",
     "copyfiles": "^2.2.0",
     "rimraf": "^3.0.2",
     "webpack": "^4.41.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,20 +1750,6 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-awesome-typescript-loader@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/awesome-typescript-loader/-/awesome-typescript-loader-5.2.1.tgz#a41daf7847515f4925cdbaa3075d61f289e913fc"
-  integrity sha512-slv66OAJB8orL+UUaTI3pKlLorwIvS4ARZzYR9iJJyGsEgOqueMfOMdKySWzZ73vIkEe3fcwFgsKMg4d8zyb1g==
-  dependencies:
-    chalk "^2.4.1"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.1.0"
-    lodash "^4.17.5"
-    micromatch "^3.1.9"
-    mkdirp "^0.5.1"
-    source-map-support "^0.5.3"
-    webpack-log "^1.2.0"
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -2190,7 +2176,7 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -3068,7 +3054,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
+enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
   integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
@@ -4974,7 +4960,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -5066,12 +5052,12 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5, lodash@^4.2.1:
+lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.2.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-log-symbols@2.2.0, log-symbols@^2.1.0:
+log-symbols@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
@@ -5100,14 +5086,6 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
-
-loglevelnext@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.5.tgz#36fc4f5996d6640f539ff203ba819641680d75a2"
-  integrity sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==
-  dependencies:
-    es6-symbol "^3.1.1"
-    object.assign "^4.1.0"
 
 lolex@^4.2.0:
   version "4.2.0"
@@ -5313,7 +5291,7 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.9:
+micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -5976,7 +5954,7 @@ object.assign@4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.assign@^4.1.0, object.assign@^4.1.1:
+object.assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
   integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
@@ -7324,7 +7302,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.3, source-map-support@~0.5.12:
+source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -8216,7 +8194,7 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -8316,16 +8294,6 @@ webpack-cli@^3.3.10:
     supports-color "^6.1.0"
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
-
-webpack-log@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
-  integrity sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==
-  dependencies:
-    chalk "^2.1.0"
-    log-symbols "^2.1.0"
-    loglevelnext "^1.0.1"
-    uuid "^3.1.0"
 
 webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"


### PR DESCRIPTION
We don't need to use typescript loader while making JS bundles anymore.
We're able to bundle by webpack all compiled by `tsc` JS files.

Also moved type definitions (`@types/properties-reader`) to the
dev. dependencies.

Resolves: OLPSUP-12416

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>