### PR TITLE
Update links

### DIFF
--- a/@here/olp-sdk-authentication/README.md
+++ b/@here/olp-sdk-authentication/README.md
@@ -64,7 +64,7 @@ In Node.js, you can use the `UserAuth` class with credentials imported from the 
 
 To use the `UserAuth` class with the credentials imported from the file:
 
-1. Download your **credentials.properties** file from the HERE platform [website](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html).
+1. Download your **credentials.properties** file from the HERE platform [website](https://developer.here.com/documentation/access-control/user-guide/topics/get-credentials.html).
 2. Create the `UserAuth` class instance and set the path to the file with your credentials.
 
     ```typescript

--- a/@here/olp-sdk-authentication/lib/loadCredentialsFromFile.ts
+++ b/@here/olp-sdk-authentication/lib/loadCredentialsFromFile.ts
@@ -22,7 +22,7 @@ import { AuthCredentials } from "./UserAuth";
 
 /**
  * Parses the **credentials.properties** file from the
- * [HERE platform](https://developer.here.com/olp/documentation/access-control/user-guide/topics/get-credentials.html)
+ * [HERE platform](https://developer.here.com/documentation/access-control/user-guide/topics/get-credentials.html)
  * and retrieves an object with user credentials.
  *
  * @param path The path to the **credentials.properties** file.

--- a/@here/olp-sdk-dataservice-api/README.md
+++ b/@here/olp-sdk-dataservice-api/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This API is generated directly from the official OpenAPI (former Swagger) definition of the [Data API](https://developer.here.com/olp/documentation/data-api/data_dev_guide/index.html).
+This API is generated directly from the official OpenAPI (former Swagger) definition of the [Data API](https://developer.here.com/documentation/data-api/data_dev_guide/index.html).
 
 ## Generate a Bundle
 

--- a/@here/olp-sdk-dataservice-api/lib/index-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/index-api.ts
@@ -22,9 +22,9 @@
  * Use the `index` service to get the data handles of the partitions that match a query.
  * Then, use the data handles with the `blob` service to get the data from the partitions.
  * For more information,
- * see [Get Data from an Index Layer](https://developer.here.com/olp/documentation/data-store/data_dev_guide/rest/getting-data-index.html).
+ * see [Get Data from an Index Layer](https://developer.here.com/documentation/data-store/data_dev_guide/rest/getting-data-index.html).
  * You can also use the `index` service to publish data to an index layer. For more information,
- * see [Publish to an Index Layer](https://developer.here.com/olp/documentation/data-store/data_dev_guide/rest/publishing-data-index.html).
+ * see [Publish to an Index Layer](https://developer.here.com/documentation/data-store/data_dev_guide/rest/publishing-data-index.html).
  *
  * OpenAPI spec version: 1.0.0
  *
@@ -82,7 +82,7 @@ export interface UpdateIndexRequest {
 
 /**
  * Adds index data for a given data blob to an index layer. For more information,
- * see [Publish to an Index Layer](https://developer.here.com/olp/documentation/data-store/data_dev_guide/rest/publishing-data-index.html).
+ * see [Publish to an Index Layer](https://developer.here.com/documentation/data-store/data_dev_guide/rest/publishing-data-index.html).
  *
  * @summary Inserts index data to an index layer
  * @param indexes An array of index attributes and values to be inserted.
@@ -124,7 +124,7 @@ export async function insertIndexes(
  * @param layerID The ID of the index layer you want to query.
  * @param query An RSQL query to use to retrieve partitions that match the query.
  * For more information, see
- * [Get Data from an Index Layer](https://developer.here.com/olp/documentation/data-store/data_dev_guide/rest/getting-data-index.html).
+ * [Get Data from an Index Layer](https://developer.here.com/documentation/data-store/data_dev_guide/rest/getting-data-index.html).
  * The query must use the indexing attributes defined in the index layer.
  * @param huge Set to true for huge query.
  */

--- a/@here/olp-sdk-dataservice-api/lib/stream-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/stream-api.ts
@@ -83,7 +83,7 @@ export interface Message {
 export interface Metadata {
     /**
      * A key that specifies which
-     * [Partition](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html)
+     * [Partition](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html)
      * the content is related to. This is provided by the user while producing to the stream layer.
      * The maximum length of the partition key is 500 characters.
      */
@@ -119,7 +119,7 @@ export interface Metadata {
     /**
      * The timestamp of the content, in milliseconds since the Unix epoch.
      * This can be provided by the user while producing to the stream layer.
-     * Refer to [NewPartition Object](https://developer.here.com/olp/documentation/data-client-library/api_reference_scala/index.html).
+     * Refer to [NewPartition Object](https://developer.here.com/documentation/data-client-library/api_reference_scala/index.html).
      * If not provided by the user, this is the timestamp when the message was produced to the stream layer
      */
     timestamp?: number;
@@ -152,7 +152,7 @@ export type KafkaProtocolVersionEnum = "0.10";
 export interface StreamOffset {
     /**
      * The partition of the stream layer for which this offset applies. It is not the same as
-     * [Partitions object](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html).
+     * [Partitions object](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html).
      */
     partition: number;
     /**
@@ -181,7 +181,7 @@ export interface StreamOffset {
  * @param subscriptionId The subscriptionId received in the response of the /subscribe request (required if mode&#x3D;parallel).
  * @param mode The subscription mode of this subscriptionId (as provided in /subscribe POST API).
  * @param xCorrelationId The correlation-id (value of Response Header &#39;X-Correlation-Id&#39;) from prior step in process.
- *  See the [API Reference](https://developer.here.com/olp/documentation/data-api/api-reference.html) for the &#x60;stream&#x60; API
+ *  See the [API Reference](https://developer.here.com/documentation/data-api/api-reference.html) for the &#x60;stream&#x60; API
  */
 export async function doCommitOffsets(
     builder: RequestBuilder,
@@ -219,7 +219,7 @@ export async function doCommitOffsets(
 
 /**
  * Consumes data from a layer. Returns messages from a stream layer formatted similar to a
- * [Partition object](https://developer.here.com/olp/documentation/data-client-library/api_reference_scala/index.html.Partition).
+ * [Partition object](https://developer.here.com/documentation/data-client-library/api_reference_scala/index.html.Partition).
  * If the data size is less than 1 MB, the `data` field will be populated.
  * If the data size is greater than 1 MB, a data handle will be returned pointing to the object stored in the Blob store.
  * The base path to be used is the value of 'nodeBaseURL' returned from /subscribe POST request.
@@ -229,7 +229,7 @@ export async function doCommitOffsets(
  * @param subscriptionId The subscriptionId received in the response of the /subscribe request (required if mode&#x3D;parallel).
  * @param mode The subscription mode of this subscriptionId (as provided in /subscribe POST API).
  * @param xCorrelationId The correlation-id (value of Response Header &#39;X-Correlation-Id&#39;) from prior step in process.
- * See the [API Reference](https://developer.here.com/olp/documentation/data-api/api-reference.html) for the &#x60;stream&#x60; API
+ * See the [API Reference](https://developer.here.com/documentation/data-api/api-reference.html) for the &#x60;stream&#x60; API
  */
 export async function consumeData(
     builder: RequestBuilder,
@@ -369,7 +369,7 @@ export async function endpointByConsumer(
  * @param subscriptionId The subscriptionId received in the response of the /subscribe request (required if mode&#x3D;parallel).
  * @param mode The subscription mode of this subscriptionId (as provided in /subscribe POST API).
  * @param xCorrelationId The correlation-id (value of Response Header &#39;X-Correlation-Id&#39;) from prior step in process.
- * See the [API Reference](https://developer.here.com/olp/documentation/data-store/api-reference.html) for the &#x60;stream&#x60; API
+ * See the [API Reference](https://developer.here.com/documentation/data-store/api-reference.html) for the &#x60;stream&#x60; API
  */
 export async function seekToOffset(
     builder: RequestBuilder,
@@ -412,17 +412,17 @@ export async function seekToOffset(
  * one unit of parallelism currently equals 1 MBps inbound or 2 MBps outbound, whichever is greater, rounded up to the nearest integer.
  * The number of subscriptions within the same group cannot exceed the parallelism allowed.
  * For more details see
- * [Get Data from a Stream Layer](https://developer.here.com/olp/documentation/data-api/data_dev_guide/rest/getting-data-stream.html).
+ * [Get Data from a Stream Layer](https://developer.here.com/documentation/data-api/data_dev_guide/rest/getting-data-stream.html).
  *
  * @summary Enable message consumption from a specific stream layer.
  * @param layerId The ID of the stream layer.
  * @param mode Specifies whether to use serial or parallel subscription mode. For more details see
- * [Get Data from a Stream Layer](https://developer.here.com/olp/documentation/data-api/data_dev_guide/rest/getting-data-stream.html).
+ * [Get Data from a Stream Layer](https://developer.here.com/documentation/data-api/data_dev_guide/rest/getting-data-stream.html).
  * @param subscriptionId Include this parameter if you want to look up the &#x60;nodeBaseURL&#x60; for a given subscriptionId.
  * @param consumerId The ID to use to identify this consumer. It must be unique within the consumer group.
  * If you do not provide one, the system will generate one.
  * @param subscriptionProperties One or more Kafka Consumer properties to use for this subscription. For more information, see
- * [Get Data from a Stream Layer](https://developer.here.com/olp/documentation/data-api/data_dev_guide/rest/getting-data-stream.html).
+ * [Get Data from a Stream Layer](https://developer.here.com/documentation/data-api/data_dev_guide/rest/getting-data-stream.html).
  */
 export async function subscribe(
     builder: RequestBuilder,

--- a/@here/olp-sdk-dataservice-read/lib/client/StreamLayerClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/StreamLayerClient.ts
@@ -71,7 +71,7 @@ export class StreamLayerClient {
      * whichever is greater, rounded up to the nearest integer.
      * The number of subscriptions within the same group cannot exceed the parallelism allowed.
      * For more details see
-     * [Get Data from a Stream Layer](https://developer.here.com/olp/documentation/data-api/data_dev_guide/rest/getting-data-stream.html)
+     * [Get Data from a Stream Layer](https://developer.here.com/documentation/data-api/data_dev_guide/rest/getting-data-stream.html)
      *
      * @param request The [[SubscribeRequest]] instance of the configured request parameters.
      * @param abortSignal A signal object that allows you to communicate with a request (such as the `fetch` request)

--- a/@here/olp-sdk-dataservice-read/lib/client/SubscribeRequest.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/SubscribeRequest.ts
@@ -104,7 +104,7 @@ export class SubscribeRequest {
      *
      * @param props The subscriptionProperties - consumer properties to use for this subscription.
      * For more information, see the [subscription properties]
-     * (https://developer.here.com/olp/documentation/data-api/data_dev_guide/rest/getting-data-stream.html#subscription-properties)
+     * (https://developer.here.com/documentation/data-api/data_dev_guide/rest/getting-data-stream.html#subscription-properties)
      * @returns The [[SubscribeRequest]] instance that you can use to chain methods.
      */
     public withSubscriptionProperties(

--- a/@here/olp-sdk-dataservice-write/README.md
+++ b/@here/olp-sdk-dataservice-write/README.md
@@ -67,7 +67,7 @@ npm run prepublish-bundle
 
 Now, we only support publishing data to a versioned layer.
 
-You can publish data to a [versioned layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#versioned-layers), if you need to store and access the history of previous data updates. To achieve consistency between layers, publish any update that affects multiple versioned layers together in one publication. You can access a new catalog version when all layers are updated, and the publication is finalized. Once you publish a version, you cannot change the data in that version and can [remove](#cancel) it only by removing the whole catalog version.
+You can publish data to a [versioned layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#versioned-layers), if you need to store and access the history of previous data updates. To achieve consistency between layers, publish any update that affects multiple versioned layers together in one publication. You can access a new catalog version when all layers are updated, and the publication is finalized. Once you publish a version, you cannot change the data in that version and can [remove](#cancel) it only by removing the whole catalog version.
 
 The maximum number of partitions you can upload and publish in one request is 1,000. If you have more than 1,000 partitions, upload the data and metadata for the first 1,000 partitions, and then do the same for the next set of partitions.
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Additionally, the Data SDK includes classes for work with geospatial tiling sche
 
 We try to develop and maintain our API in a way that preserves its compatibility with the existing applications. Changes in Data SDK for TypeScript are greatly influenced by the Data API development. Data API introduces breaking changes 6 months in advance. Therefore, you may need to migrate to a new version of Data SDK for TypeScript every half a year.
 
-For more information on Data API, see its <a href="https://developer.here.com/olp/documentation/data-api/data_dev_guide/index.html" target="_blank">Developer Guide</a> and <a href="https://developer.here.com/olp/documentation/data-api/api-reference.html" target="_blank">API Reference</a>.
+For more information on Data API, see its <a href="https://developer.here.com/documentation/data-api/data_dev_guide/index.html" target="_blank">Developer Guide</a> and <a href="https://developer.here.com/documentation/data-api/api-reference.html" target="_blank">API Reference</a>.
 
 When new API is introduced in Data SDK for TypeScript, the old one is not deleted straight away. The standard API deprecation time is 6 months. It gives you time to switch to new code. However, we do not provide ABI backward compatibility.
 
-All of the deprecated methods, functions, and parameters are documented in the Data SDK for TypeScript <a href="https://developer.here.com/olp/documentation/sdk-typescript/api_reference/index.html"  target="_blank">API Reference</a> and <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/CHANGELOG.md" target="_blank">changelog</a>.
+All of the deprecated methods, functions, and parameters are documented in the Data SDK for TypeScript <a href="https://developer.here.com/documentation/sdk-typescript/api_reference/index.html"  target="_blank">API Reference</a> and <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/CHANGELOG.md" target="_blank">changelog</a>.
 
 For more information on Data SDK for TypeScrypt, see our <a href="https://developer.here.com/documentation/sdk-typescript/dev_guide/index.html" target="blank">Developer Guide</a>.
 

--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -23,12 +23,12 @@ Working with the Data SDK requires knowledge of the following subjects:
 
 To use Data SDK for TypeScript, you need to understand the following concepts related to the HERE platform:
 
-* [Catalogs](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/catalogs.html)
-* [Layers](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html)
-* [Partitions](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html)
-* [HERE Resource Names (HRNs)](https://developer.here.com/olp/documentation/data-user-guide/shared_content/topics/olp/concepts/hrn.html)
+* [Catalogs](https://developer.here.com/documentation/data-user-guide/portal/layers/catalogs.html)
+* [Layers](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html)
+* [Partitions](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html)
+* [HERE Resource Names (HRNs)](https://developer.here.com/documentation/data-user-guide/shared_content/topics/concepts/hrn.html)
 
-For more details, see the [Data User Guide](https://developer.here.com/olp/documentation/data-user-guide/index.html).
+For more details, see the [Data User Guide](https://developer.here.com/documentation/data-user-guide/index.html).
 
 ## Get credentials
 

--- a/docs/read-from-index-layer.md
+++ b/docs/read-from-index-layer.md
@@ -65,7 +65,7 @@ App works!
 
 ## Create `IndexLayerClient`
 
-You can use the `IndexLayerClient` object to request any data and partition metadata from an [index layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#index-layers).
+You can use the `IndexLayerClient` object to request any data and partition metadata from an [index layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#index-layers).
 
 **To create the `IndexLayerClient` object:**
 
@@ -85,7 +85,7 @@ You can use the `IndexLayerClient` object to request any data and partition meta
 
 ## Get partition metadata from an index layer
 
-Partition metadata from [index layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#index-layers) consists of the following information about the partition:
+Partition metadata from [index layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#index-layers) consists of the following information about the partition:
 
 - ID (data handle)
 - Data size
@@ -131,7 +131,7 @@ const partitions = await indexLayerClient.getPartitions(request),
 
 ## Get data from an index layer
 
-An [index layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#index-layers) is an index of the catalog data by attributes. You can query the index layer to get the data handles of data that meets your query criteria, and you can then use those data handles to retrieve the corresponding data.
+An [index layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#index-layers) is an index of the catalog data by attributes. You can query the index layer to get the data handles of data that meets your query criteria, and you can then use those data handles to retrieve the corresponding data.
 
 **To get data from the index layer:**
 

--- a/docs/read-from-stream-layer.md
+++ b/docs/read-from-stream-layer.md
@@ -65,7 +65,7 @@ App works!
 
 ## Create `StreamLayerClient`
 
-You can use the `StreamLayerClient` class to request data from the queue that streams data from a [stream layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#stream-layers). Once a consumer reads the data, the data is no longer available to that consumer, but the data remains available to other consumers.
+You can use the `StreamLayerClient` class to request data from the queue that streams data from a [stream layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#stream-layers). Once a consumer reads the data, the data is no longer available to that consumer, but the data remains available to other consumers.
 
 Stream layers can be configured with retention time, or time-to-live (TTL) which results in unconsumed data being removed after a specified period.
 
@@ -121,7 +121,7 @@ Now, to get data, you can call the `Poll` method.
 
 ## <a name="get-data-streamlayerclient"></a>Get data and partition metadata from a stream layer
 
-You can read messages from a [stream layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#stream-layers) if you subscribe to the layer. The messages contain data and the following partition metadata:
+You can read messages from a [stream layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#stream-layers) if you subscribe to the layer. The messages contain data and the following partition metadata:
 
 - Data handle
 - ID

--- a/docs/read-from-versioned-layer.md
+++ b/docs/read-from-versioned-layer.md
@@ -65,7 +65,7 @@ App works!
 
 ## Create `VersionedLayerClient`
 
-You can use the `VersionedLayerClient` object to request any data and partition metadata version from a [versioned layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#versioned-layers). When you request a particular version of data from the versioned layer, the partition you receive in the response may have a lower version number than you requested. The version of a layer or partition represents the catalog version in which the layer or partition was last updated.
+You can use the `VersionedLayerClient` object to request any data and partition metadata version from a [versioned layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#versioned-layers). When you request a particular version of data from the versioned layer, the partition you receive in the response may have a lower version number than you requested. The version of a layer or partition represents the catalog version in which the layer or partition was last updated.
 
 **To create the `VersionedLayerClient` object:**
 
@@ -91,7 +91,7 @@ You can use the `VersionedLayerClient` object to request any data and partition 
 
 ## Get partition metadata from a versioned layer
 
-Partition metadata from a [versioned layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#versioned-layers) consists of the following information about the partition:
+Partition metadata from a [versioned layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#versioned-layers) consists of the following information about the partition:
 
 - Data handle
 - ID
@@ -105,7 +105,7 @@ You can get partition metadata in one of the following ways:
 - Using the Metadata Service API
 - Using the Query Service API
  
-You can get partition metadata using the Query Service API only if the partition has the HERE tile scheme. For more information on the HERE tile scheme, see [Partitions](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html).
+You can get partition metadata using the Query Service API only if the partition has the HERE tile scheme. For more information on the HERE tile scheme, see [Partitions](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html).
 
 For performance reasons, it is best to use the Query Service API only to get metadata for a specific partition. For batch processes, and to get metadata for many partitions or all partitions in a layer, use the Metadata Service API.
 
@@ -180,7 +180,7 @@ const partitions = await versionedLayerClient.getPartitions(
 
 ## Get data from a versioned layer
 
-You can request any data version from a [versioned layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#versioned-layers). When you request a particular version of data from the versioned layer, the partition you receive in the response may have a lower version number than you requested. The version of a layer or partition represents the catalog version in which the layer or partition was last updated.
+You can request any data version from a [versioned layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#versioned-layers). When you request a particular version of data from the versioned layer, the partition you receive in the response may have a lower version number than you requested. The version of a layer or partition represents the catalog version in which the layer or partition was last updated.
 
 **To get data from the versioned layer:**
 

--- a/docs/read-from-volatile-layer.md
+++ b/docs/read-from-volatile-layer.md
@@ -65,7 +65,7 @@ App works!
 
 ## Create `VolatileLayerClient`
 
-You can use the `VolatileLayerClient` object to get the latest published data and partition metadata from a [volatile layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#volatile-layers).
+You can use the `VolatileLayerClient` object to get the latest published data and partition metadata from a [volatile layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#volatile-layers).
 
 **To create the `VolatileLayerClient` object:**
 
@@ -85,7 +85,7 @@ You can use the `VolatileLayerClient` object to get the latest published data an
 
 ## Get partition metadata from a volatile layer
 
-Partition metadata from a [volatile layer](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/layers.html#volatile-layers) consists of the following information about the partition:
+Partition metadata from a [volatile layer](https://developer.here.com/documentation/data-user-guide/portal/layers/layers.html#volatile-layers) consists of the following information about the partition:
 
 - Data handle
 - ID
@@ -98,7 +98,7 @@ You can get partition metadata in one of the following ways:
 - Using the Metadata Service API
 - Using the Query Service API
 
-You can get partition metadata using the Query Service API only if the partition has the HERE tile scheme. For more information on the HERE tile scheme, see [Partitions](https://developer.here.com/olp/documentation/data-user-guide/portal/layers/partitions.html).
+You can get partition metadata using the Query Service API only if the partition has the HERE tile scheme. For more information on the HERE tile scheme, see [Partitions](https://developer.here.com/documentation/data-user-guide/portal/layers/partitions.html).
 
 For performance reasons, it is best to use the Query Service API only to get metadata for a specific partition. For batch processes, and to get metadata for many partitions or all partitions in a layer, use the Metadata Service API.
 

--- a/examples/react-app-example/README.md
+++ b/examples/react-app-example/README.md
@@ -34,6 +34,6 @@ In the project directory, you can run the following scripts:
 
 For more information, see the following documentation:
 
-- Data API <a href="https://developer.here.com/olp/documentation/data-api/data_dev_guide/index.html" target="_blank">Developer Guide</a> and <a href="https://developer.here.com/olp/documentation/data-api/api-reference.html" target="_blank">API Reference</a>
+- Data API <a href="https://developer.here.com/documentation/data-api/data_dev_guide/index.html" target="_blank">Developer Guide</a> and <a href="https://developer.here.com/documentation/data-api/api-reference.html" target="_blank">API Reference</a>
 - [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started)
 - [React documentation](https://reactjs.org/)


### PR DESCRIPTION
DHC is about to remove the redirection on their side, so all links like
developer.here.com/olp/documentation should be updated to be
developer.here.com/documentation

Relates-To: OLPEDGE-2441
Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>