### PR TITLE
Add generated Blob API v2 functions, interfaces

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/blob.v2.api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/blob.v2.api.ts
@@ -222,6 +222,341 @@ export interface ValidationError {
     correlationId?: string;
 }
 
+/*
+ * ===================================================================
+ * ByHandleApi
+ * ===================================================================
+ */
+
+/**
+ * Cancels an entire multipart upload operation.
+ *
+ * @summary Cancels a multipart upload.
+ * @param layerId The ID of the parent layer for this blob.
+ * @param multipartToken The identifier of the multipart upload (token).
+ * Content of this parameter must refer to a valid token which when the multipart upload was initiated.
+ */
+export async function cancelMultipartUploadByHandle(
+    builder: RequestBuilder,
+    params: { layerId: string; multipartToken: string }
+): Promise<Response> {
+    const baseUrl = "/layers/{layerId}/handlesMultipart/{multipartToken}"
+        .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
+        .replace(
+            "{multipartToken}",
+            UrlBuilder.toString(params["multipartToken"])
+        );
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "DELETE",
+        headers
+    };
+
+    return builder.requestBlob(urlBuilder, options);
+}
+
+/**
+ * Checks if a blob exists for the requested data handle.
+ *
+ * @summary Checks if a data handle exists.
+ * @param layerId The ID of the parent layer for this blob.
+ * @param handle The data handle identifies a specific blob so that you can get that blob&#39;s contents.
+ */
+export async function checkHandleExists(
+    builder: RequestBuilder,
+    params: { layerId: string; handle: string }
+): Promise<Response> {
+    const baseUrl = "/layers/{layerId}/handles/{handle}"
+        .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
+        .replace("{handle}", UrlBuilder.toString(params["handle"]));
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "HEAD",
+        headers
+    };
+
+    return builder.requestBlob(urlBuilder, options);
+}
+
+/**
+ * Call this API when all parts have been uploaded.
+ *
+ * @summary Completes a multipart upload.
+ * @param layerId The ID of the parent layer for this blob.
+ * @param multipartToken The identifier of the multipart upload (token).
+ * Content of this parameter must refer to a valid token which when the multipart upload was initiated.
+ * @param body The part IDs uploaded in this multipart upload, which should be used in the resulting blob.
+ */
+export async function completeMultipartUploadByHandle(
+    builder: RequestBuilder,
+    params: {
+        layerId: string;
+        multipartToken: string;
+        body?: MultipartCompleteRequest;
+    }
+): Promise<Response> {
+    const baseUrl = "/layers/{layerId}/handlesMultipart/{multipartToken}"
+        .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
+        .replace(
+            "{multipartToken}",
+            UrlBuilder.toString(params["multipartToken"])
+        );
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "PUT",
+        headers
+    };
+    headers["Content-Type"] = "application/json";
+    if (params["body"] !== undefined) {
+        options.body = JSON.stringify(params["body"]);
+    }
+
+    return builder.requestBlob(urlBuilder, options);
+}
+
+/**
+ * Deletes a data blob.
+ *
+ * @summary Deletes a data blob.
+ * @param layerId The ID of the parent layer for this blob.
+ * @param handle The data handle identifies a specific blob so that you can get that blob&#39;s contents.
+ */
+export async function deleteBlobByHandle(
+    builder: RequestBuilder,
+    params: { layerId: string; handle: string }
+): Promise<Response> {
+    const baseUrl = "/layers/{layerId}/handles/{handle}"
+        .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
+        .replace("{handle}", UrlBuilder.toString(params["handle"]));
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "DELETE",
+        headers
+    };
+
+    return builder.requestBlob(urlBuilder, options);
+}
+
+/**
+ * Retrieves a blob from storage.
+ *
+ * @summary Gets a blob.
+ * @param layerId The ID of the parent layer for this blob.
+ * @param handle The data handle identifies a specific blob so that you can get that blob&#39;s contents.
+ * @param range Use this parameter to resume download of a large response when there is a connection
+ * issue between the client and server, or to fetch a specific slice of the blob.
+ * To resume download after a connection issue, specify a single byte range offset as
+ * follows: 'Range: bytes=10-'. To fetch a specific slice of the blob, specify a slice as follows: 'Range: bytes=10-100'.
+ * This parameter is compliant with [RFC 7233](https://tools.ietf.org/html/rfc7233),
+ * but note that this parameter only supports a single byte range. The 'range'
+ * parameter can also be specified as a query parameter, i.e. 'range=bytes=10-'.
+ */
+export async function getBlobByHandle(
+    builder: RequestBuilder,
+    params: { layerId: string; handle: string; range?: string }
+): Promise<string> {
+    const baseUrl = "/layers/{layerId}/handles/{handle}"
+        .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
+        .replace("{handle}", UrlBuilder.toString(params["handle"]));
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "GET",
+        headers
+    };
+    if (params["range"] !== undefined) {
+        headers["Range"] = params["range"] as string;
+    }
+
+    return builder.request<string>(urlBuilder, options);
+}
+
+/**
+ * Gets the status of a multipart upload.
+ *
+ * @summary Gets the status of a multipart upload.
+ * @param layerId The ID of the parent layer for this blob.
+ * @param multipartToken The identifier of the multipart upload (token).
+ * Content of this parameter must refer to a valid token which when the multipart upload was initiated.
+ */
+export async function getMultipartUploadStatusByHandle(
+    builder: RequestBuilder,
+    params: { layerId: string; multipartToken: string }
+): Promise<MultipartHandleUploadStatus> {
+    const baseUrl = "/layers/{layerId}/handlesMultipart/{multipartToken}"
+        .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
+        .replace(
+            "{multipartToken}",
+            UrlBuilder.toString(params["multipartToken"])
+        );
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "GET",
+        headers
+    };
+
+    return builder.request<MultipartHandleUploadStatus>(urlBuilder, options);
+}
+
+/**
+ * Persists the data blob up to 192 MB. When the operation completes successfully,
+ * there is no guarantee that the data blob will be immediately available although,
+ * in most cases, it will be. To check if the data blob is available, use the `HEAD` method.
+ *
+ * @summary Publishes a data blob.
+ * @param body Request body.
+ * @param layerId The ID of the parent layer for this blob.
+ * @param contentLength Size of the entity-body, in bytes. For more information,
+ * see [RFC 7230, section 3.3.2: Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2).
+ */
+export async function postBlob(
+    builder: RequestBuilder,
+    params: { body: string; layerId: string; contentLength: number }
+): Promise<DataHandleResponse> {
+    const baseUrl = "/layers/{layerId}/handles".replace(
+        "{layerId}",
+        UrlBuilder.toString(params["layerId"])
+    );
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "POST",
+        headers
+    };
+    headers["Content-Type"] = "application/json";
+    if (params["body"] !== undefined) {
+        options.body = JSON.stringify(params["body"]);
+    }
+    if (params["contentLength"] !== undefined) {
+        headers["Content-Length"] = (params[
+            "contentLength"
+        ] as unknown) as string;
+    }
+
+    return builder.request<DataHandleResponse>(urlBuilder, options);
+}
+
+/**
+ * Publishes large data blobs where the data payload needs to be split into multiple parts.
+ * The multipart upload start is to be followed by the individual parts upload and completed with a call to complete the upload.
+ * The limit of the blob uploaded this way is 50GB.
+ *
+ * @summary Starts a multipart upload.
+ * @param body An object that contains metadata of the uploaded object.
+ * @param layerId The ID of the parent layer for this blob.
+ */
+export async function startMultipartUploadByHandle(
+    builder: RequestBuilder,
+    params: { body: MultipartUploadByHandleMetadata; layerId: string }
+): Promise<MultipartInitResponse> {
+    const baseUrl = "/layers/{layerId}/handlesMultipart".replace(
+        "{layerId}",
+        UrlBuilder.toString(params["layerId"])
+    );
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "POST",
+        headers
+    };
+    headers["Content-Type"] = "application/json";
+    if (params["body"] !== undefined) {
+        options.body = JSON.stringify(params["body"]);
+    }
+
+    return builder.request<MultipartInitResponse>(urlBuilder, options);
+}
+
+/**
+ * Upload a single part of a multipart upload for the blob.
+ * Every uploaded part except the last one must have a minimum 5 MB of data and a maximum of 96 MB.
+ * The length of every part except the last one must be a multiple of 1MB (1024KB). The maximum number of parts is 10,000.
+ *
+ * @summary Uploads a part.
+ * @param body The data to upload as part of the blob.
+ * @param layerId The ID of the parent layer for this blob.
+ * @param multipartToken The identifier of the multipart upload (token). Content of this parameter must refer to a
+ * valid token which when the multipart upload was initiated.
+ * @param partNumber The number of the part for the multi part upload. The numbers of the upload parts must start from 1,
+ * be no greater than 10,000 and be consecutive. Parts uploaded with the same 'partNumber' are overridden. Do not reuse
+ * the same 'partNumber' when retrying an upload in an error situation (network problems, 4xx or 5xx responses).
+ * Reusing the same 'partNumber' in a retry may cause the publication to fail.
+ * @param contentLength Size of the entity-body, in bytes. For more information,
+ * see [RFC 7230, section 3.3.2: Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2).
+ * @param contentType A standard MIME type describing the format of the blob data.
+ * For more information, see [RFC 2616, section 14.17: Content-Type](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17).
+ * The value of this header must match the content type specified in the 'contentType' field when the multipart upload was initialized,
+ * and this content type must also match the content type specified in the layer&#39;s configuration.
+ */
+export async function uploadPartByHandle(
+    builder: RequestBuilder,
+    params: {
+        body: string;
+        layerId: string;
+        multipartToken: string;
+        partNumber: number;
+        contentLength: number;
+        contentType: string;
+    }
+): Promise<PartId> {
+    const baseUrl = "/layers/{layerId}/handlesMultipart/{multipartToken}/parts"
+        .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
+        .replace(
+            "{multipartToken}",
+            UrlBuilder.toString(params["multipartToken"])
+        );
+
+    const urlBuilder = new UrlBuilder(builder.baseUrl + baseUrl);
+    urlBuilder.appendQuery("partNumber", params["partNumber"]);
+
+    const headers: { [header: string]: string } = {};
+    const options: RequestOptions = {
+        method: "POST",
+        headers
+    };
+    headers["Content-Type"] = "application/json";
+    if (params["body"] !== undefined) {
+        options.body = JSON.stringify(params["body"]);
+    }
+    if (params["contentLength"] !== undefined) {
+        headers["Content-Length"] = (params[
+            "contentLength"
+        ] as unknown) as string;
+    }
+    if (params["contentType"] !== undefined) {
+        headers["Content-Type"] = params["contentType"] as string;
+    }
+
+    return builder.request<PartId>(urlBuilder, options);
+}
+
+/*
+ * ===================================================================
+ * ByKeyApi
+ * ===================================================================
+ */
+
 /**
  * Cancels an entire multipart upload operation. You can only cancel a multipart upload before it has been completed.
  *
@@ -233,7 +568,7 @@ export interface ValidationError {
 export async function cancelMultipartUploadByKey(
     builder: RequestBuilder,
     params: { layerId: string; multipartToken: string }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/keysMultipart/{multipartToken}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace(
@@ -249,7 +584,7 @@ export async function cancelMultipartUploadByKey(
         headers
     };
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -263,7 +598,7 @@ export async function cancelMultipartUploadByKey(
 export async function checkKeyExists(
     builder: RequestBuilder,
     params: { layerId: string; key: string }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/keys/{key}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{key}", UrlBuilder.toString(params["key"]));
@@ -276,7 +611,7 @@ export async function checkKeyExists(
         headers
     };
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -295,7 +630,7 @@ export async function completeMultipartUploadByKey(
         multipartToken: string;
         body?: MultipartCompleteRequest;
     }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/keysMultipart/{multipartToken}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace(
@@ -315,7 +650,7 @@ export async function completeMultipartUploadByKey(
         options.body = JSON.stringify(params["body"]);
     }
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -329,7 +664,7 @@ export async function completeMultipartUploadByKey(
 export async function deleteBlobByKey(
     builder: RequestBuilder,
     params: { layerId: string; key: string }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/keys/{key}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{key}", UrlBuilder.toString(params["key"]));
@@ -342,7 +677,7 @@ export async function deleteBlobByKey(
         headers
     };
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -363,7 +698,7 @@ export async function deleteBlobByKey(
 export async function getBlobByKey(
     builder: RequestBuilder,
     params: { layerId: string; key: string; range?: string }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/keys/{key}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{key}", UrlBuilder.toString(params["key"]));
@@ -379,7 +714,7 @@ export async function getBlobByKey(
         headers["Range"] = params["range"];
     }
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -477,7 +812,7 @@ export async function putBlobByKey(
         body?: string;
         source?: string;
     }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/keys/{key}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{key}", UrlBuilder.toString(params["key"]));


### PR DESCRIPTION
Adding functions and interfaces for `by datahandle` APIs,
auto generated by the code generator.

Fix response types for some funcitons.

Relates-To: OLPEDGE-2348

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>