### PR TITLE
Fix types for Promise.

### DIFF
--- a/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
+++ b/@here/olp-sdk-core/lib/utils/DataStoreDownloadManager.ts
@@ -33,7 +33,7 @@ class DeferredPromise<T> {
      * Internal promise to store the deferred executor function.
      */
     readonly promise: Promise<T>;
-    private resolveFunc?: (result?: T) => void;
+    private resolveFunc?: (result?: T | PromiseLike<T>) => void;
     private rejectFunc?: (reason?: any) => void;
 
     constructor(private readonly executor: () => Promise<T>) {


### PR DESCRIPTION
The type for resolve function should be:
```
new <T>(executor: (resolve: (value?: T | PromiseLike<T>) =>
	void, reject: (reason?: any) => void) => void): Promise<T>;
```

as described
in types node_modules/typescript/lib/lib.es2015.promise.d.ts

Resolves: OLPEDGE-2446

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>