### PR TITLE
Change Lookup API host for SIT

### DIFF
--- a/@here/olp-sdk-core/lib/utils/getEnvLookupUrl.ts
+++ b/@here/olp-sdk-core/lib/utils/getEnvLookupUrl.ts
@@ -60,7 +60,7 @@ export function getEnvLookUpUrl(env: EnvironmentName): string {
 
     switch (env) {
         case "here-dev":
-            return "https://api-lookup.data.api.platform.in.here.com/lookup/v1";
+            return "https://api-lookup.data.api.platform.sit.here.com/lookup/v1";
         case "here-cn":
             return "https://api-lookup.data.api.platform.hereolp.cn/lookup/v1";
         case "here-cn-dev":

--- a/@here/olp-sdk-core/test/unit/getEnvLookupUrl.test.ts
+++ b/@here/olp-sdk-core/test/unit/getEnvLookupUrl.test.ts
@@ -37,7 +37,7 @@ describe("getEnvLookUpUrl", function() {
 
     it("Should return url to the development instance", function() {
         expect(getEnvLookUpUrl("here-dev")).to.be.equal(
-            "https://api-lookup.data.api.platform.in.here.com/lookup/v1"
+            "https://api-lookup.data.api.platform.sit.here.com/lookup/v1"
         );
     });
 


### PR DESCRIPTION
The URL to the SIT lookup API has been changed,
so we should adapt our code to the new endpoint.

Resolves: OLPEDGE-2468

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>