### PR TITLE
Move function isValid to core

### DIFF
--- a/@here/olp-sdk-core/lib/utils/TileKey.ts
+++ b/@here/olp-sdk-core/lib/utils/TileKey.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,6 +236,30 @@ export class TileKey implements QuadKey {
      */
     static parentMortonCode(mortonCode: number): number {
         return Math.floor(mortonCode / 4);
+    }
+
+    /**
+     * Checks if a quadkey is valid.
+     *
+     * The number of rows and columns must not be greater than the maximum number of rows and columns in the given level.
+     * The maximum number of rows and columns in a level is computed as 2 to the power of the level.
+     *
+     * @note As the JavaScript number type can hold 53 bits in its mantissa, only levels up to 26 can be
+     * represented in the number representation returned by [[mortonCodeFromQuadKey]].
+     * A level must be positive and can't be greater than 26.
+     *
+     * @param key The current quadkey.
+     * @return True if the quadkey is valid, false otherwise.
+     */
+    static isValid(key: QuadKey): boolean {
+        // tslint:disable-next-line:no-magic-numbers
+        if (key.level < 0 || key.level > 26) {
+            return false;
+        }
+        const dimensionAtLevel = Math.pow(2, key.level);
+        const rowValid = key.row >= 0 && key.row < dimensionAtLevel;
+        const columnValid = key.column >= 0 && key.column < dimensionAtLevel;
+        return rowValid && columnValid;
     }
 
     /**

--- a/@here/olp-sdk-core/test/unit/TileKey.test.ts
+++ b/@here/olp-sdk-core/test/unit/TileKey.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,5 +230,27 @@ describe("TileKey", function() {
                 "Cannot get the parent of the root tile key"
             );
         }
+    });
+
+    it("Tile is not valid if the row/column is out of bounds", function() {
+        const invalid_tile_1 = { row: 5, column: 1, level: 1 };
+        assert.isFalse(TileKey.isValid(invalid_tile_1));
+
+        const invalid_tile_2 = { row: -5, column: 1, level: 1 };
+        assert.isFalse(TileKey.isValid(invalid_tile_2));
+
+        const invalid_tile_3 = { row: 1, column: 5, level: 1 };
+        assert.isFalse(TileKey.isValid(invalid_tile_3));
+
+        const invalid_tile_4 = { row: 1, column: -5, level: 1 };
+        assert.isFalse(TileKey.isValid(invalid_tile_4));
+    });
+
+    it("Tile is not valid if the level is out of bounds", function() {
+        const invalid_tile_1 = { row: 0, column: 0, level: -1 };
+        assert.isFalse(TileKey.isValid(invalid_tile_1));
+
+        const invalid_tile_2 = { row: 0, column: 0, level: 100 };
+        assert.isFalse(TileKey.isValid(invalid_tile_2));
     });
 });

--- a/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
+++ b/@here/olp-sdk-dataservice-read/lib/client/QueryClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ import {
     FetchOptions,
     HRN,
     OlpClientSettings,
-    RequestFactory
+    RequestFactory,
+    TileKey
 } from "@here/olp-sdk-core";
 import {
     AdditionalFields,
@@ -29,7 +30,6 @@ import {
     QueryApi
 } from "@here/olp-sdk-dataservice-api";
 import {
-    isValid,
     MetadataCacheRepository,
     mortonCodeFromQuadKey,
     PartitionsRequest,
@@ -70,7 +70,7 @@ export class QueryClient {
         const quadKey = request.getQuadKey();
         const layerId = request.getLayerId();
 
-        if (!quadKey || !isValid(quadKey)) {
+        if (!quadKey || !TileKey.isValid(quadKey)) {
             return Promise.reject("Please provide correct QuadKey");
         }
 

--- a/@here/olp-sdk-dataservice-read/lib/utils/QuadKeyUtils.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/QuadKeyUtils.ts
@@ -101,7 +101,7 @@ const powerOfTwo = [
 // tslint:enable:no-magic-numbers
 
 /**
- * @deprecated This function will be removed by 02.2021.
+ * @deprecated This function will be removed by 08.2021.
  * Please use the same method from [[TileKey]] class, imported from `@here/olp-sdk-core` package.
  *
  * Creates a quadkey from a numeric or string Morton code representation.


### PR DESCRIPTION
The function isValid should be moved to the core
TileKey class as a method.

Copied to the TileKey and deprecated the original one.

Relates-To: OLPEDGE-2466

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>