### PR TITLE
Fix bug in config-api.

### DIFF
--- a/@here/olp-sdk-dataservice-api/lib/config-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/config-api.ts
@@ -1015,7 +1015,7 @@ export type PackageTypeEnum = "experimental" | "small" | "medium" | "large";
 export async function catalogExists(
     builder: RequestBuilder,
     params: { catalogHrn: string; billingTag?: string }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/catalogs/{catalogHrn}".replace(
         "{catalogHrn}",
         UrlBuilder.toString(params["catalogHrn"])
@@ -1030,7 +1030,7 @@ export async function catalogExists(
         headers
     };
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**

--- a/@here/olp-sdk-dataservice-api/test/ConfigApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/ConfigApi.test.ts
@@ -35,7 +35,7 @@ describe("ConfigApi", function() {
         };
         const builder = {
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/catalogs/mocked-catalogHrn?billingTag=mocked-billingTag"
                 );


### PR DESCRIPTION
The function catalogExists should not parse the
response as json. This CR fixes the crash if user call the
function.

Resolves: OLPEDGE-2504

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>