### PR TITLE
Travis:NPM publish process improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: node_js
 node_js:
   - lts/*
 cache: yarn
+git:
+  quiet: true
 env:
   global:
   - WORKSPACE=$TRAVIS_BUILD_DIR

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -61,6 +61,6 @@ sleep 60
 echo 'Publish verification...'
 yarn
 yarn bootstrap
-npm run build
-npm run http-server-testing-bundles & npm run test-published-bundles
+npm run --silent build
+npm run --silent http-server-testing-bundles & npm run --silent test-published-bundles
 echo 'Publish verification done! '


### PR DESCRIPTION
Less verbose log, less git logs.
Travis logs limit in 50000 lines, os I hope
we will not reach it again in publish job.

Relates-To: OLPEDGE-2321

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>