### PR TITLE
TypedEvent class.

### DIFF
--- a/@here/olp-sdk-core/lib/utils/TypedEvent.ts
+++ b/@here/olp-sdk-core/lib/utils/TypedEvent.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+/**
+ * The event handler function.
+ */
+export type Listener<T> = (event: T) => any;
+
+/**
+ * The simple implementation of Event Emmiter with types.
+ */
+export class TypedEvent<T> {
+    private listeners: Listener<T>[] = [];
+
+    /**
+     * Adds the `listener` function to the end of the array of listeners for the event.
+     * No checks are made to see if the listener has already been added.
+     * Multiple calls passing the listener can result in it being added
+     * and called multiple times.
+     *
+     * @param listener The event handler function.
+     *
+     * @returns A callback for removing the added listener.
+     */
+    on(listener: Listener<T>): { dispose: () => void } {
+        this.listeners.push(listener);
+        return {
+            dispose: () => {
+                this.off(listener);
+            }
+        };
+    }
+
+    /**
+     * Removes the specified listener from the listener array for the event.
+     *
+     * @param listener The event handler function.
+     */
+    off(listener: Listener<T>) {
+        const callbackIndex = this.listeners.indexOf(listener);
+        if (callbackIndex > -1) {
+            this.listeners.splice(callbackIndex, 1);
+        }
+    }
+
+    /**
+     * Calls each of the listeners synchronously in the order in which
+     * they were registered, passing the supplied argument to each.
+     *
+     * @param event The `Event` object.
+     */
+    emit(event: T) {
+        this.listeners.forEach(listener => listener(event));
+    }
+}

--- a/@here/olp-sdk-core/lib/utils/index.ts
+++ b/@here/olp-sdk-core/lib/utils/index.ts
@@ -45,3 +45,4 @@ export * from "./FetchOptions";
 export * from "./TileKey";
 export * from "./Uuid";
 export * from "./userAgent";
+export * from "./TypedEvent";

--- a/@here/olp-sdk-core/test/unit/TypedEvent.test.ts
+++ b/@here/olp-sdk-core/test/unit/TypedEvent.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as chai from "chai";
+import sinonChai = require("sinon-chai");
+import { TypedEvent } from "@here/olp-sdk-core";
+
+chai.use(sinonChai);
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("TypedEvent", function() {
+    it("on", function() {
+        const event = new TypedEvent<number>();
+        const subscribtion = event.on(res => {
+            expect(res).equals(4);
+        });
+
+        expect(subscribtion.dispose).not.to.be.undefined;
+
+        event.emit(4);
+    });
+
+    it("off", function() {
+        const event = new TypedEvent<number>();
+        let handlerCalls = 0;
+        const subscribtion = event.on(() => {
+            handlerCalls++;
+        });
+
+        event.emit(4);
+        subscribtion.dispose();
+        event.emit(4);
+
+        expect(handlerCalls).equals(1);
+    });
+
+    it("off with empty listeners should not be crashed", function() {
+        const event = new TypedEvent<number>();
+        event.off(() => true);
+        assert(event !== undefined);
+    });
+});


### PR DESCRIPTION
Adding the simple EventEmmiter implementation to use
events in the same way in Browsers and Node.js.
Also supports the types.

Relates-To: OLPEDGE-2456
Closes: OLPEDGE-2531

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>