### PR TITLE
Implementation for reading bytes from file in Node

### DIFF
--- a/@here/olp-sdk-core/index.ts
+++ b/@here/olp-sdk-core/index.ts
@@ -22,3 +22,5 @@ import "@here/olp-sdk-fetch";
 
 export * from "./lib";
 export * from "./lib.version";
+
+export * as fs from "fs";

--- a/@here/olp-sdk-core/lib/utils/BlobData.ts
+++ b/@here/olp-sdk-core/lib/utils/BlobData.ts
@@ -38,7 +38,13 @@ export abstract class BlobData {
     /**
      * Gets the size of the data.
      *
-     * @returns The length of the data in bytes.
+     * @returns The `Promise` object with the length of the data in bytes.
      */
     abstract size(): number;
+
+    /**
+     * This method should always be called at the end of the reading process
+     * so that we can properly clean up.
+     */
+    abstract finally?(): Promise<void>;
 }

--- a/@here/olp-sdk-core/lib/utils/multipartupload-internal/NodeFileData.ts
+++ b/@here/olp-sdk-core/lib/utils/multipartupload-internal/NodeFileData.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { BlobData, fs } from "@here/olp-sdk-core";
+
+/**
+ * @internal
+ * Implementation of reading bytes from file by filepath
+ * in Node.js.
+ */
+export class NodeFileData implements BlobData {
+    private readonly fileHandle: fs.promises.FileHandle;
+    private readonly fileStats: fs.Stats;
+
+    constructor(opts: {
+        fileHandle: fs.promises.FileHandle;
+        fileStats: fs.Stats;
+    }) {
+        this.fileHandle = opts.fileHandle;
+        this.fileStats = opts.fileStats;
+    }
+
+    static async fromPath(filePath: string): Promise<BlobData> {
+        const fileHandle = await fs.promises.open(filePath, "r");
+        const fileStats = await fileHandle.stat();
+        return new NodeFileData({ fileStats, fileHandle });
+    }
+
+    async readBytes(offset: number, count: number): Promise<ArrayBuffer> {
+        const fileSize = this.size();
+
+        const bufferLength =
+            offset + count > fileSize ? fileSize - offset : count;
+
+        const buffer = Buffer.alloc(bufferLength);
+        const chunk = await this.fileHandle.read(
+            buffer,
+            0,
+            bufferLength,
+            offset
+        );
+        return chunk.buffer;
+    }
+
+    size(): number {
+        return this.fileStats.size;
+    }
+
+    async finally() {
+        await this.fileHandle.close();
+    }
+}

--- a/@here/olp-sdk-core/package.json
+++ b/@here/olp-sdk-core/package.json
@@ -4,7 +4,7 @@
   "description": "Core features of the HERE Data Platform",
   "main": "index.js",
   "browser": "index.web.js",
-  "typings": "index.web",
+  "typings": "index",
   "directories": {
     "test": "test",
     "lib": "lib"

--- a/@here/olp-sdk-core/test/unit/NodeFileData.test.ts
+++ b/@here/olp-sdk-core/test/unit/NodeFileData.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as sinon from "sinon";
+import * as chai from "chai";
+import * as fs from "fs";
+import sinonChai = require("sinon-chai");
+import { NodeFileData } from "../../lib/utils/multipartupload-internal/NodeFileData";
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe("NodeFileData", function() {
+    let fsOpen: sinon.SinonStub;
+
+    afterEach(() => {
+        fsOpen.restore();
+    });
+
+    it("readBytes", async function() {
+        fsOpen = sinon.stub(fs.promises, "open").returns({
+            stat: () => Promise.resolve({ size: 9 }),
+            read: (
+                buffer: Buffer,
+                offset?: number | null,
+                length?: number | null,
+                position?: number | null
+            ) => {
+                expect(buffer.length).eqls(5);
+                expect(offset).eqls(0);
+                expect(length).eqls(5);
+                expect(position).eqls(2);
+                return Promise.resolve({
+                    buffer: Buffer.from("12345", "utf-8")
+                });
+            }
+        } as any);
+
+        const data = await NodeFileData.fromPath("fake-filepath");
+        const bytes = await data.readBytes(2, 5);
+        expect(bytes.toString()).eqls("12345");
+
+        fsOpen.restore();
+        fsOpen = sinon.stub(fs.promises, "open").returns({
+            stat: () => Promise.resolve({ size: 9 }),
+            read: (
+                buffer: Buffer,
+                offset?: number | null,
+                length?: number | null,
+                position?: number | null
+            ) => {
+                expect(buffer.length).eqls(4);
+                expect(offset).eqls(0);
+                expect(length).eqls(4);
+                expect(position).eqls(5);
+                return Promise.resolve({
+                    buffer: Buffer.from("12345", "utf-8")
+                });
+            }
+        } as any);
+        const data2 = await NodeFileData.fromPath("fake-filepath");
+        await data2.readBytes(5, 6);
+    });
+
+    it("size", async function() {
+        fsOpen = sinon.stub(fs.promises, "open").returns({
+            stat: () => Promise.resolve({ size: 9 })
+        } as any);
+        const data = await NodeFileData.fromPath("fake-filepath");
+        expect(data.size()).eqls(9);
+    });
+
+    it("closing file handle", async function() {
+        let closeCalls = 0;
+        fsOpen = sinon.stub(fs.promises, "open").returns({
+            close: () => {
+                closeCalls++;
+                return Promise.resolve();
+            },
+            stat: () => Promise.resolve({ size: 9 })
+        } as any);
+        const data = await NodeFileData.fromPath("fake-filepath");
+        expect(data.size()).not.undefined;
+        expect(data.finally).not.undefined;
+
+        data.finally && (await data.finally());
+        expect(closeCalls).eqls(1);
+    });
+
+    it("negative test, catch wrong file path", async function() {
+        try {
+            await NodeFileData.fromPath("fake-filepath");
+        } catch (error) {
+            expect(error.message).eqls(
+                "ENOENT: no such file or directory, open 'fake-filepath'"
+            );
+            expect(error.code).eqls("ENOENT");
+        }
+    });
+});


### PR DESCRIPTION
- Adding implementation for reading bytes and getting the data size from file
by filepath in Node.js.

- Change typings source from `index.web` to `index`.
- Export `fs` in `index` to be able compile Node related
code only in Node.js and avoid compile errors for Browsers.

Relates-To: OLPEDGE-2456
Resolves: OLPEDGE-2536

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>