### PR TITLE
Use MultipartuploadWrapper in layer client.

### DIFF
--- a/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/VersionedLayerClient.test.ts
@@ -745,7 +745,7 @@ describe("VersionedLayerClient write", function() {
 
         const response = await client.uploadBlob(request).catch(e => e);
         expect(response.message).equals(
-            "Error uploading chunk 1, can't read ETag from headers."
+            "Error uploading chunk 1, can not read ETag from the response headers."
         );
     });
 


### PR DESCRIPTION
Replace the old multipart upload logic in the `DataserviceWrite->VersionedLayerClient` by using `MultipartUploadWrapper`.
    
Relates-To: OLPEDGE-2456
Resolves: OLPEDGE-2541
    
Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>