### PR TITLE
Fix bug with chunks numbers

### DIFF
--- a/@here/olp-sdk-dataservice-write/lib/utils/MultiPartUploadWrapper.ts
+++ b/@here/olp-sdk-dataservice-write/lib/utils/MultiPartUploadWrapper.ts
@@ -319,16 +319,16 @@ export class MultiPartUploadWrapper {
                         })
                         .then(uploadPartResponse => {
                             parts.push({
-                                id: uploadPartResponse.id,
-                                number: chunkNumber
+                                id: uploadPartResponse.partId,
+                                number: uploadPartResponse.partNumber
                             });
 
                             uploadedChunks++;
 
                             this.opts.onStatus &&
                                 this.opts.onStatus({
-                                    chunkId: uploadPartResponse.id,
-                                    chunkNumber,
+                                    chunkId: uploadPartResponse.partId,
+                                    chunkNumber: uploadPartResponse.partNumber,
                                     chunkSize: buffer.byteLength,
                                     totalChunks,
                                     uploadedChunks

--- a/@here/olp-sdk-dataservice-write/lib/utils/multipartupload-internal/BlobV1UploadRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/utils/multipartupload-internal/BlobV1UploadRequest.ts
@@ -79,7 +79,10 @@ export class BlobV1UploadRequest implements UploadRequest {
         partNumber: number;
         contentLength: number;
         billingTag?: string;
-    }): Promise<{ id: string }> {
+    }): Promise<{
+        partNumber: number;
+        partId: string;
+    }> {
         const result = await BlobApi.doUploadPart(this.requestBuilder, {
             body: opts.data,
             contentLength: opts.contentLength,
@@ -89,8 +92,8 @@ export class BlobV1UploadRequest implements UploadRequest {
             billingTag: opts.billingTag
         });
 
-        const id = result.headers.get("ETag");
-        if (!id) {
+        const partId = result.headers.get("ETag");
+        if (!partId) {
             return Promise.reject(
                 new Error(
                     `Error uploading chunk ${opts.partNumber}, can not read ETag from the response headers.`
@@ -98,7 +101,7 @@ export class BlobV1UploadRequest implements UploadRequest {
             );
         }
 
-        return { id };
+        return { partNumber: opts.partNumber, partId };
     }
 
     async completeMultipartUpload(opts: {

--- a/@here/olp-sdk-dataservice-write/lib/utils/multipartupload-internal/BlobV2UploadRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/utils/multipartupload-internal/BlobV2UploadRequest.ts
@@ -66,7 +66,10 @@ export class BlobV2UploadRequest implements UploadRequest {
         partNumber: number;
         contentLength?: number;
         contentType?: string;
-    }): Promise<{ id: string }> {
+    }): Promise<{
+        partNumber: number;
+        partId: string;
+    }> {
         const result = await ObjectStoreApi.uploadPartByKey(
             this.requestBuilder,
             {
@@ -87,7 +90,7 @@ export class BlobV2UploadRequest implements UploadRequest {
             );
         }
 
-        return { id: result.id };
+        return { partNumber: opts.partNumber, partId: result.id };
     }
 
     async completeMultipartUpload(opts: {

--- a/@here/olp-sdk-dataservice-write/lib/utils/multipartupload-internal/UploadRequest.ts
+++ b/@here/olp-sdk-dataservice-write/lib/utils/multipartupload-internal/UploadRequest.ts
@@ -45,7 +45,8 @@ export abstract class UploadRequest {
         contentLength?: number;
         billingTag?: string;
     }): Promise<{
-        id: string;
+        partNumber: number;
+        partId: string;
     }>;
 
     abstract completeMultipartUpload(opts: {

--- a/@here/olp-sdk-dataservice-write/test/unit/BlobV1UploadRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/BlobV1UploadRequest.test.ts
@@ -134,7 +134,8 @@ describe("BlobV1UploadRequest", function() {
             billingTag
         });
 
-        expect(result.id).equals("mocked-id");
+        expect(result.partId).equals("mocked-id");
+        expect(result.partNumber).equals(23);
 
         expect(blobApiStub).calledWith(mockedRequestBuilder, {
             url,

--- a/@here/olp-sdk-dataservice-write/test/unit/BlobV2UploadRequest.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/BlobV2UploadRequest.test.ts
@@ -119,7 +119,8 @@ describe("BlobV2UploadRequest", function() {
             partNumber
         });
 
-        expect(result.id).equals("mocked-part-id");
+        expect(result.partId).equals("mocked-part-id");
+        expect(result.partNumber).equals(23);
 
         expect(blobApiStub).calledWith(mockedRequestBuilder, {
             layerId,

--- a/@here/olp-sdk-dataservice-write/test/unit/MultiPartUploadWrapper.test.ts
+++ b/@here/olp-sdk-dataservice-write/test/unit/MultiPartUploadWrapper.test.ts
@@ -57,9 +57,10 @@ describe("MultiPartUploadWrapper", async function() {
                     uploadPartUrl: "mocked-upload-part-url",
                     completeUrl: "mocked-complete-url"
                 }),
-                uploadPart: sinon
-                    .stub()
-                    .resolves({ id: "mocked-uploaded-part-id" }),
+                uploadPart: sinon.stub().resolves({
+                    partId: "mocked-uploaded-part-id",
+                    partNumber: 1
+                }),
                 completeMultipartUpload: sinon.stub()
             };
 
@@ -159,9 +160,10 @@ describe("MultiPartUploadWrapper", async function() {
                 startMultipartUpload: sinon.stub().resolves({
                     multipartToken: "mocked-multipartToken"
                 }),
-                uploadPart: sinon
-                    .stub()
-                    .resolves({ id: "mocked-uploaded-part-id" }),
+                uploadPart: sinon.stub().resolves({
+                    partNumber: 1,
+                    partId: "mocked-uploaded-part-id"
+                }),
                 completeMultipartUpload: sinon.stub()
             };
 
@@ -256,9 +258,10 @@ describe("MultiPartUploadWrapper", async function() {
                 startMultipartUpload: sinon.stub().resolves({
                     multipartToken: "mocked-multipartToken"
                 }),
-                uploadPart: sinon
-                    .stub()
-                    .resolves({ id: "mocked-uploaded-part-id" }),
+                uploadPart: sinon.stub().resolves({
+                    partNumber: 1,
+                    partId: "mocked-uploaded-part-id"
+                }),
                 completeMultipartUpload: sinon.stub()
             };
 
@@ -342,9 +345,10 @@ describe("MultiPartUploadWrapper", async function() {
                 startMultipartUpload: sinon.stub().resolves({
                     multipartToken: "mocked-multipartToken"
                 }),
-                uploadPart: sinon
-                    .stub()
-                    .resolves({ id: "mocked-uploaded-part-id" }),
+                uploadPart: sinon.stub().resolves({
+                    partNumber: 1,
+                    partId: "mocked-uploaded-part-id"
+                }),
                 completeMultipartUpload: sinon.stub()
             };
 
@@ -392,12 +396,12 @@ describe("MultiPartUploadWrapper", async function() {
 
             expect(completeMultipartUploadCallParams.parts).eqls([
                 { id: "mocked-uploaded-part-id", number: 1 },
-                { id: "mocked-uploaded-part-id", number: 2 },
-                { id: "mocked-uploaded-part-id", number: 3 },
-                { id: "mocked-uploaded-part-id", number: 4 },
-                { id: "mocked-uploaded-part-id", number: 5 },
-                { id: "mocked-uploaded-part-id", number: 6 },
-                { id: "mocked-uploaded-part-id", number: 7 }
+                { id: "mocked-uploaded-part-id", number: 1 },
+                { id: "mocked-uploaded-part-id", number: 1 },
+                { id: "mocked-uploaded-part-id", number: 1 },
+                { id: "mocked-uploaded-part-id", number: 1 },
+                { id: "mocked-uploaded-part-id", number: 1 },
+                { id: "mocked-uploaded-part-id", number: 1 }
             ]);
             expect(completeMultipartUploadCallParams.layerId).eqls(
                 "mocked-layer-id"
@@ -420,9 +424,10 @@ describe("MultiPartUploadWrapper", async function() {
                 startMultipartUpload: sinon.stub().resolves({
                     multipartToken: "mocked-multipartToken"
                 }),
-                uploadPart: sinon
-                    .stub()
-                    .resolves({ id: "mocked-uploaded-part-id" }),
+                uploadPart: sinon.stub().resolves({
+                    partNumber: 1,
+                    partId: "mocked-uploaded-part-id"
+                }),
                 completeMultipartUpload: sinon.stub()
             };
 
@@ -471,7 +476,7 @@ describe("MultiPartUploadWrapper", async function() {
 
             expect(completeMultipartUploadCallParams.parts).eqls([
                 { id: "mocked-uploaded-part-id", number: 1 },
-                { id: "mocked-uploaded-part-id", number: 2 }
+                { id: "mocked-uploaded-part-id", number: 1 }
             ]);
             expect(completeMultipartUploadCallParams.layerId).eqls(
                 "mocked-layer-id"


### PR DESCRIPTION
The array of chunks for the `completeMultipartUpload`
request was incorrect and looked like this:

```
{
    id: '"HASH"',
    number: 6
  },
  {
    id: '"HASH"',
    number: 6
  },
  {
    id: '"HASH"',
    number: 6
  },
  {
    id: '"HASH"',
    number: 6
  },
  {
    id: '"HASH"',
    number: 6
  },
  {
    id: '"HASH"',
    number: 6
  },
  {
    id: '"HASH"',
    number: 12
  },
  {
    id: '"HASH"',
    number: 12
  },
  {
    id: '"HASH"',
    number: 12
  },
  {
    id: '"HASH"',
    number: 12
  },
  {
    id: '"HASH"',
    number: 12
  },
  {
    id: '"HASH"',
    number: 12
  }
```

The request was failing with error:
`400: One or more of the specified parts could not be found.
The part may not have been uploaded.`

The fix uses the chunk number from the uploaded response
instead of the counter.

Relates-To: OLPEDGE-2456

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>