### PR TITLE
Making the path platform agnostic in help command text

### DIFF
--- a/examples/nodejs-example/options.ts
+++ b/examples/nodejs-example/options.ts
@@ -19,6 +19,7 @@
 
 import yargs from "yargs";
 const homedir = require("os").homedir();
+const path = require("path");
 
 export const options = yargs
   .usage(`Usage: -c <catalog> -l <layer> ...optional params`)
@@ -26,7 +27,7 @@ export const options = yargs
     alias: "credentials",
     describe: "Path to your credentials file",
     type: "string",
-    default: `${homedir}/.here/credentials.properties`
+    default: path.join(homedir, ".here", "credentials.properties")
   })
   .option("c", {
     alias: "catalog",


### PR DESCRIPTION
Concatenating to show the path in the help command shows invalid path under Windows. 
![Screenshot of issue](https://user-images.githubusercontent.com/13433697/126520676-a9ac725c-2b92-4c7c-891c-875495e55799.png)

Using path.join shows the correct path
![Screenshot after fix](https://user-images.githubusercontent.com/13433697/126520895-0cbd00aa-4114-4e3f-9601-54b793c70308.png)
