### PR TITLE
Update documentation

### DIFF
--- a/@here/olp-sdk-core/README.md
+++ b/@here/olp-sdk-core/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This repository contains the complete source code for the HERE Data SDK Core for TypeScript `@here/olp-sdk-core` project. `olp-sdk-core` is a TypeScript library that contains the common code for `@here/olp-sdk-dataservice-read`, `@here/olp-sdk-dataservice-api` and `@here/olp-sdk-authentication`.
+This repository contains the complete source code for the HERE Data SDK Core for TypeScript `@here/olp-sdk-core` project. `olp-sdk-core` is a TypeScript library that contains the common code for `@here/olp-sdk-dataservice-read`, `@here/olp-sdk-dataservice-api`, and `@here/olp-sdk-authentication`.
 
 ## Directory Layout
 

--- a/docs/create-platform-client-settings.md
+++ b/docs/create-platform-client-settings.md
@@ -6,10 +6,10 @@ You need to create the `OlpClientSettings` object to publish data and get catalo
 
 1. [Authenticate](authenticate.md) to the HERE platform.
 
-2. Import the `OlpClientSettings` class from the `olp-sdk-dataservice-read` module.
+2. Import the `OlpClientSettings` class from the `olp-sdk-core` module.
 
    ```typescript
-   import { OlpClientSettings } from "@here/olp-sdk-dataservice-read";
+   import { OlpClientSettings } from "@here/olp-sdk-core";
    ```
 
 3. Create the `olpClientSettings` instance using the environment in which you work and the `getToken` method.


### PR DESCRIPTION
`OlpClientSettings` are now imported from `@here/olp-sdk-core`.

Relates-To: OLPEDGE-2609
Signed-off-by: Halyna Dumych <ext-halyna.dumych@here.com>