### PR TITLE
Fix full regression report generation job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,11 +49,10 @@ regression_generate_report_job:
   when: manual
   tags:
   - docker-prod
-  image: python:3.6
+  image: python:3.8
   before_script:
-    - pip install junit2html
+    - pip install junit2html==26
   script:
-    - python -m junit2htmlreport --report-matrix index.html ./*.xml
     - python -m junit2htmlreport --report-matrix api-breaks-index.html ./api-breaks-xunit.xml
     - python -m junit2htmlreport --report-matrix fetch-index.html ./olp-sdk-fetch-xunit.xml
     - python -m junit2htmlreport --report-matrix integration-index.html ./integration-xunit.xml
@@ -63,32 +62,14 @@ regression_generate_report_job:
     - python -m junit2htmlreport --report-matrix dataservice-api-index.html ./olp-sdk-dataservice-api-xunit.xml
     - python -m junit2htmlreport --report-matrix dataservice-read-index.html ./olp-sdk-dataservice-read-xunit.xml
     - python -m junit2htmlreport --report-matrix dataservice-write-index.html ./olp-sdk-dataservice-write-xunit.xml
-    - sed -i -e 's/Reports\ Matrix/API-Breaks\ Test\ Report/g' ./api-breaks-index.html
-    - sed -i -e 's/Reports\ Matrix/Fetch\ Test\ Report/g' ./fetch-index.html
-    - sed -i -e 's/Reports\ Matrix/Integration\ Test\ Report/g' ./integration-index.html
-    - sed -i -e 's/Reports\ Matrix/Functional\ Test\ Report/g' ./functional-index.html
-    - sed -i -e 's/Reports\ Matrix/Authentication\ Test\ Report/g' ./authentication-index.html
-    - sed -i -e 's/Reports\ Matrix/Core\ Test\ Report/g' ./core-index.html
-    - sed -i -e 's/Reports\ Matrix/Dataservice-api\ Test\ Report/g' ./dataservice-api-index.html
-    - sed -i -e 's/Reports\ Matrix/Dataservice-read\ Test\ Report/g' ./dataservice-read-index.html
-    - sed -i -e 's/Reports\ Matrix/Dataservice-write\ Test\ Report/g' ./dataservice-write-index.html
-    - sed -i -e 's/Reports\ Matrix/Full\ Regression\ Test\ Report/g' ./index.html
-    - cat ./authentication-index.html >> ./index.html
-    - cat ./core-index.html >> ./index.html
-    - cat ./dataservice-api-index.html >> ./index.html
-    - cat ./dataservice-read-index.html >> ./index.html
-    - cat ./dataservice-write-index.html >> ./index.html
-    - cat ./fetch-index.html >> ./index.html
-    - cat ./functional-index.html >> ./index.html
-    - cat ./integration-index.html >> ./index.html
-    - cat ./api-breaks-index.html >> ./index.html
-    - mkdir -p .public
-    - cp index.html .public/
+    - ./scripts/misc/full_report_generation.sh
     - if $(ls $CI_PROJECT_DIR/index.html &>/dev/null); then tar -czf ${CI_JOB_NAME}_test_reports.tar.gz --directory=$CI_PROJECT_DIR index.html ; fi;
     - $CI_PROJECT_DIR/scripts/misc/artifactory_upload.sh edge-sdks/sdk-for-typescript/test-reports/$CI_JOB_NAME/$CI_JOB_ID/${CI_JOB_NAME}_test_reports.tar.gz ${CI_JOB_NAME}_test_reports.tar.gz
   artifacts:
     paths:
       - .public
+      - ./*.html
+      - ./*.xml
     when: always
     expire_in: 3 yrs # save our zip for 3 years as job artifacts
   only:

--- a/scripts/misc/full_report_generation.sh
+++ b/scripts/misc/full_report_generation.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -ex
+#
+# Copyright (C) 2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# Simple script that create full regression html report with list of different tests
+
+# Replacing default title with specific test group names
+sed -i -e 's/Reports\ Matrix/API-Breaks\ Test\ Report/g' ./api-breaks-index.html
+sed -i -e 's/Reports\ Matrix/Fetch\ Test\ Report/g' ./fetch-index.html
+sed -i -e 's/Reports\ Matrix/Integration\ Test\ Report/g' ./integration-index.html
+sed -i -e 's/Reports\ Matrix/Functional\ Test\ Report/g' ./functional-index.html
+sed -i -e 's/Reports\ Matrix/Authentication\ Test\ Report/g' ./authentication-index.html
+sed -i -e 's/Reports\ Matrix/Core\ Test\ Report/g' ./core-index.html
+sed -i -e 's/Reports\ Matrix/Dataservice-api\ Test\ Report/g' ./dataservice-api-index.html
+sed -i -e 's/Reports\ Matrix/Dataservice-read\ Test\ Report/g' ./dataservice-read-index.html
+sed -i -e 's/Reports\ Matrix/Dataservice-write\ Test\ Report/g' ./dataservice-write-index.html
+
+# Creating new html files
+echo "<html> <head> <title>Full Regression Test Report</title> </head><h2>Full Regression Test Report</h2></html>" > ./index.html
+# Authentication
+cat ./authentication-index.html >> ./index.html
+# Core
+cat ./core-index.html >> ./index.html
+# DS API
+cat ./dataservice-api-index.html >> ./index.html
+# DS READ
+cat ./dataservice-read-index.html >> ./index.html
+# DS WRITE
+cat ./dataservice-write-index.html >> ./index.html
+# Fetch
+cat ./fetch-index.html >> ./index.html
+# Functional
+cat ./functional-index.html >> ./index.html
+# Integration
+cat ./integration-index.html >> ./index.html
+# API-Breaks
+cat ./api-breaks-index.html >> ./index.html
+
+mkdir -p .public
+cp index.html .public/
+


### PR DESCRIPTION
Regression report fix:
- use older image version of python and junit2html;
- make report generation inside separate bash script.

Relates-To: OLPEDGE-2560

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>