### PR TITLE
Release 1.12.0

### DIFF
--- a/@here/olp-sdk-authentication/package.json
+++ b/@here/olp-sdk-authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-authentication",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Wrapper around the HERE Authentication and Authorization REST API obtaining short-lived access tokens that are used to authenticate requests to HERE services.",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,7 +49,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "^1.6.0",
+    "@here/olp-sdk-core": "^1.7.0",
     "@here/olp-sdk-fetch": "^1.9.0",
     "properties-reader": "^0.3.1"
   },

--- a/@here/olp-sdk-core/lib.version.ts
+++ b/@here/olp-sdk-core/lib.version.ts
@@ -17,4 +17,4 @@
  * License-Filename: LICENSE
  */
 
-export const LIB_VERSION = "1.11.1";
+export const LIB_VERSION = "1.12.0";

--- a/@here/olp-sdk-core/package.json
+++ b/@here/olp-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-core",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Core features of the HERE Data Platform",
   "main": "index.js",
   "browser": "index.web.js",
@@ -50,7 +50,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@here/olp-sdk-fetch": "^1.9.0",
-    "@here/olp-sdk-dataservice-api": "^1.11.0"
+    "@here/olp-sdk-dataservice-api": "^1.12.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/@here/olp-sdk-dataservice-api/package.json
+++ b/@here/olp-sdk-dataservice-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-api",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Generated from the OpenAPI specification of the HERE Open Location Platform Data API",
   "main": "index.js",
   "typings": "index",

--- a/@here/olp-sdk-dataservice-read/package.json
+++ b/@here/olp-sdk-dataservice-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-read",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Wrapper around a subset of the HERE Open Location Platform Data REST API related to reading data from OLP catalogs",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,8 +49,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "^1.6.0",
-    "@here/olp-sdk-dataservice-api": "^1.11.0",
+    "@here/olp-sdk-core": "^1.7.0",
+    "@here/olp-sdk-dataservice-api": "^1.12.0",
     "@here/olp-sdk-fetch": "^1.9.0"
   },
   "devDependencies": {

--- a/@here/olp-sdk-dataservice-write/package.json
+++ b/@here/olp-sdk-dataservice-write/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-write",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Wrapper around a subset of the HERE Open Location Platform Data REST API related to writing data to OLP catalogs",
   "main": "index.js",
   "browser": "index.web.js",
@@ -50,8 +50,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "^1.6.0",
-    "@here/olp-sdk-dataservice-api": "^1.11.0",
+    "@here/olp-sdk-core": "^1.7.0",
+    "@here/olp-sdk-dataservice-api": "^1.12.0",
     "@here/olp-sdk-fetch": "^1.9.0"
   },
   "devDependencies": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## v1.12.0 (30/08/2021)
+
+**olp-sdk-core**
+
+- Updated the `@here/olp-sdk-dataservice-api` dependency.
+
+**olp-sdk-authentication**
+
+- Removed the deprecated code (https://github.com/heremaps/here-data-sdk-typescript/pull/485).
+- Updated the `@here/olp-sdk-core` dependency.
+
+**olp-sdk-dataservice-api**
+
+- Updated the generated code for `ConfigAPI` with information on the `InteractiveMap` and `ObjectStore` layer types.
+- Updated the `date` types for the `Schema`, `Artifact`, and `KeysListObjectItemResponse` interfaces of `ArtifactAPI`.
+- Removed the deprecated code (https://github.com/heremaps/here-data-sdk-typescript/pull/485).
+
+**olp-sdk-dataservice-read**
+
+- Removed the deprecated code (https://github.com/heremaps/here-data-sdk-typescript/pull/485).
+- Updated the `@here/olp-sdk-core` dependency.
+- Updated the `@here/olp-sdk-dataservice-api` dependency.
+
+**olp-sdk-dataservice-write**
+
+- Updated the `@here/olp-sdk-core` dependency.
+- Updated the `@here/olp-sdk-dataservice-api` dependency.
+
 ## v1.11.1 (17/06/2021)
 
 **olp-sdk-dataservice-write**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-ts",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "HERE OLP SDK for TypeScript",
   "author": {
     "name": "HERE Europe B.V.",


### PR DESCRIPTION
- update versions.
- update CHANGELOG.
- update unit test for oauth with mocked HMAC.

Resolves: OLPEDGE-2622

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>