### PR TITLE
Not throw on sparse data layers.

### DIFF
--- a/@here/olp-sdk-dataservice-read/lib/utils/getTile.ts
+++ b/@here/olp-sdk-dataservice-read/lib/utils/getTile.ts
@@ -149,7 +149,12 @@ export async function getTile(
     }
 
     if (!quadTreeIndex.subQuads || !quadTreeIndex.subQuads.length) {
-        return Promise.reject(new Error("Error fetching QuadTreeIndex"));
+        return Promise.resolve(
+            new Response("No Content", {
+                status: 204,
+                statusText: "No Content"
+            })
+        );
     }
 
     // Return the data for the requested QuadKey or for the closest parent


### PR DESCRIPTION
The issue is about throwing an error by SDK in case of
an empty QuadTreeIndex response.

SDK returns 204 response with this fix.

Resolves: OLPSUP-16894

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>