### PR TITLE
Update readme: copyright, node version, replace Travis CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+      - run: scripts/misc/commit_checker.sh
+      - run: scripts/linux/psv/build_test_psv.sh && env
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+         fail_ci_if_error: true
+         verbose: true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ HERE Data SDK for TypeScript is a TypeScript client for the <a href="https://pla
 
 | Master                      | Node version       | Status                                                                                                                                                                                         |
 | :-------------------------- | :----------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Build/Test/Bundling/Typedoc | Node 12.13.0 (LTS) | <a href="https://app.travis-ci.com/heremaps/here-data-sdk-typescript" target="_blank"><img src="https://app.travis-ci.com/heremaps/here-data-sdk-typescript.svg?branch=master" alt="Build Status"></a> |
+| Build/Test/Bundling/Typedoc | Node 16.13.2 (LTS) | <a href="https://app.travis-ci.com/heremaps/here-data-sdk-typescript" target="_blank"><img src="https://app.travis-ci.com/heremaps/here-data-sdk-typescript.svg?branch=master" alt="Build Status"></a> |
 
 ### Test coverage
 
@@ -173,6 +173,6 @@ npm run bundle
 
 ## LICENSE
 
-Copyright (C) 2019–2021 HERE Europe B.V.
+Copyright (C) 2019–2022 HERE Europe B.V.
 
 For license details, see the <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/LICENSE" target="_blank">LICENSE</a> file in the root of this project.

--- a/scripts/linux/psv/build_test_psv.sh
+++ b/scripts/linux/psv/build_test_psv.sh
@@ -50,4 +50,4 @@ npm run functional-test
 npm run http-server-testing-bundles & npm run test-generated-bundles
 
 # Generate and upload codecov
-( npm run codecov && ./node_modules/.bin/codecov ) || ( echo "CodeCov exited with non-zero, please investigate!" && exit 1 )
+npm run codecov


### PR DESCRIPTION
Set proper lts node version which is used in Travis CI.
Update year to 2022.

Relates-To: OLPEDGE-2449

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>