### PR TITLE
Update job naming for GH Actions,enable AzureCI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,26 @@
-name: Node.js CI
+name: Typescript PSV CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - '*'
 
 jobs:
-  build:
-
+  psv-linux-build-test-codecov:
+    name: PSV / Linux Build / Tests / Code coverage
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '16.x'
-      - run: scripts/misc/commit_checker.sh
-      - run: scripts/linux/psv/build_test_psv.sh && env
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-         fail_ci_if_error: true
-         verbose: true
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '16'
+        cache: npm
+    - name: Build / Tests / Coverage
+      run: scripts/linux/psv/build_test_psv.sh
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,16 @@
+trigger:
+- master
+pr:
+- master
+
+variables:
+  BUILD_TYPE: "RelWithDebInfo"
+
+jobs:
+- job: Commit_checker
+  pool:
+    vmImage: 'ubuntu-latest'
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+  steps:
+    - bash: scripts/misc/commit_checker.sh
+      displayName: 'Commit checker script'

--- a/scripts/misc/commit_checker.sh
+++ b/scripts/misc/commit_checker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (C) 2020 HERE Europe B.V.
+# Copyright (C) 2020-2022 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,43 +26,51 @@
 echo "`git log --pretty=format:'%B' -2 | sed '1d' | sed '1d' `" >> commit.log
 
 # Counting number of lines in file
-num_lines=`wc -l commit.log| cut -d'c' -f1` 
+num_lines=`wc -l commit.log | cut -d'c' -f1`
 
 # Loop for every line in file
 for (( line=1; line<=${num_lines}; line++ ))
 do
-    current_line_len=`cat commit.log| sed -n ${line}p |wc -m | sed 's/\ \ \ \ \ \ /''/g' `
+    current_line_len=`cat commit.log | sed -n ${line}p | tr -d '\n\r' | wc -m | sed 's/\ \ \ \ \ \ /''/g' `
     if [ $line -eq 1 ] && [ ${current_line_len} -gt 50 ] ; then
         echo ""
-        echo "ERROR: Title is ${current_line_len} length, so it's too long for title. Expect less than 50 chars !"
+        echo "ERROR: Title is ${current_line_len} length, so it's too long for title. Expect less than or equal to 50 chars !"
         echo ""
+        cat commit.log
+        echo "----------------------------------------------"
         echo "Please read following rules:"
         cat scripts/misc/commit_message_recom.txt
-        exit 1
+        exit 6
     fi
-    if [ $line -eq 2 ] && [ ${current_line_len} -ne 1 ] ; then
+    if [ $line -eq 2 ] && [ ${current_line_len} -ne 0 ] ; then
         echo ""
         echo "ERROR: Second line in Commit Message is not zero length !"
         echo ""
+        cat commit.log
+        echo "----------------------------------------------"
         echo "Please read following rules:"
         cat scripts/misc/commit_message_recom.txt
-        exit 1
+        exit 5
     fi
-    if [ $line -eq 3 ] && [ ${current_line_len} -lt 1 ] && [ -n $(cat commit.log| sed -n ${line}p | grep 'See also: ') ] && [ -n $(cat commit.log| sed -n ${line}p | grep 'Relates-To: ') ] && [ -n $(echo ${current_line_len}| grep 'Resolves: ') ] ; then
+    if [ "$line" -eq 3 ] && ( [ "$current_line_len" -le 1 ] || [ -n "$(cat commit.log | sed -n ${line}p | grep 'See also: ')" ] || [ -n "$(cat commit.log | sed -n ${line}p | grep 'Relates-To: ')" ] || [ -n "$(cat commit.log | sed -n ${line}p | grep 'Resolves: ')" ] ) ; then
         echo ""
-        echo "ERROR: No details added to commit message besides title !"
+        echo "ERROR: No details added to commit message besides title and ticket reference!"
         echo ""
+        cat commit.log
+        echo "----------------------------------------------"
         echo "Please read following rules:"
         cat scripts/misc/commit_message_recom.txt
-        exit 1
+        exit 4
     fi
     if [ ${current_line_len} -gt 72 ] ; then
         echo ""
-        echo "ERROR: ${current_line_len} chars in ${line}-th line is too long. Any line length must be less than 72 chars !"
+        echo "ERROR: ${current_line_len} chars in ${line}-th line is too long. Any line length must be less than or equal to 72 chars !"
         echo ""
+        cat commit.log
+        echo "----------------------------------------------"
         echo "Please read following rules:"
         cat scripts/misc/commit_message_recom.txt
-        exit 1
+        exit 3
     fi
     echo " ${line}-th line is ${current_line_len} chars length . OK."
 done
@@ -71,6 +79,7 @@ done
 here_user_commit=$(cat commit.log | grep '@here.com') || true
 
 if [[ -n ${here_user_commit}  ]] ; then
+
     echo ""
     echo "Commit message contains here user sign-off with here email. OK."
     echo "Ticket reference is mandatory!"
@@ -80,16 +89,28 @@ if [[ -n ${here_user_commit}  ]] ; then
     resolves=$(cat commit.log | grep 'Resolves: ') || true
     see=$(cat commit.log | grep 'See also: ') || true
 
-    echo "Reference like:  ${relates_to} ${resolves} ${see}  was found in commit message. OK."
-
-    if [[ -n ${relates_to} || -n ${resolves} || -n ${see} ]] ; then
-        echo ""
-        echo "Commit message contains issue reference. OK."
-        echo ""
+    # This is verification that we have any of these possible issue references.
+    if [[ -n "${relates_to}" ]] || [[ -n "${resolves}" ]] || [[ -n "${see}" ]] ; then
+            echo ""
+            echo "Commit message contains issue reference. OK."
+            echo "Reference like:  ${relates_to} ${resolves} ${see}  was found in commit message. OK."
+        # This verification is needed for correct Jira linking in Gitlab.
+        if [[ "$(echo ${relates_to}| cut -d":" -f2)" =~ [a-z] ]] || [[ "$(echo ${resolves}| cut -d":" -f2)" =~ [a-z] ]] || [[ "$(echo ${see}| cut -d":" -f2)" =~ [a-z] ]] ; then
+            echo ""
+            echo "ERROR: Commit message contains ticket or issue reference in lower case !"
+            echo ""
+            cat commit.log
+            echo "----------------------------------------------"
+            echo "Please read following rules:"
+            cat scripts/misc/commit_message_recom.txt
+            exit 2
+        fi
     else
         echo ""
         echo "ERROR: Commit message does not contain ticket or issue reference like Relates-To: or Resolves: or See also:  !"
         echo ""
+        cat commit.log
+        echo "----------------------------------------------"
         echo "Please read following rules:"
         cat scripts/misc/commit_message_recom.txt
         exit 1


### PR DESCRIPTION
Make naming more standard.
Move commit checker job to Azure pipelines
due to issues with GH Actions git approach.

Relates-To: OLPEDGE-2449

Signed-off-by: Yaroslav Stefinko <ext-yaroslav.stefinko@here.com>