### PR TITLE
Update Data SDK for Typescript documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 HERE Data SDK for TypeScript is a TypeScript client for the <a href="https://platform.here.com" target="_blank">HERE platform</a>.
 
+## Use the SDK
+
+To learn how to install and use the Data SDK, see the <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/docs/GettingStartedGuide.md" target="_blank">Getting Started Guide</a> and <a href="https://developer.here.com/documentation/sdk-typescript/dev_guide/index.html" target="blank">Developer Guide</a>.
+
 ## Health check
 
 ### Build and test
@@ -24,9 +28,9 @@ For more information on Data API, see its <a href="https://developer.here.com/do
 
 When new API is introduced in Data SDK for TypeScript, the old one is not deleted straight away. The standard API deprecation time is 6 months. It gives you time to switch to new code. However, we do not provide ABI backward compatibility.
 
-All of the deprecated methods, functions, and parameters are documented in the Data SDK for TypeScript <a href="https://developer.here.com/documentation/sdk-typescript/api_reference/index.html"  target="_blank">API Reference</a> and <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/CHANGELOG.md" target="_blank">changelog</a>.
+Learn more about deprecated methods, functions, and parameters in the Data SDK for TypeScript <a href="https://developer.here.com/documentation/sdk-typescript/api_reference/index.html"  target="_blank">API Reference</a> and <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/CHANGELOG.md" target="_blank">changelog</a>.
 
-For more information on Data SDK for TypeScrypt, see our <a href="https://developer.here.com/documentation/sdk-typescript/dev_guide/index.html" target="blank">Developer Guide</a>.
+For more information on Data SDK for TypeScript, see our <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/docs/GettingStartedGuide.md" target="_blank">Getting Started Guide</a> and <a href="https://developer.here.com/documentation/sdk-typescript/dev_guide/index.html" target="blank">Developer Guide</a>.
 
 ## About this repository
 

--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -4,13 +4,21 @@ HERE Data SDK for TypeScript includes the core components to access the HERE API
 
 In this guide, learn how to authenticate to and start working with the HERE platform using the Data SDK:
 
-- [Getting Started Guide](#getting-started-guide)
-  - [Prerequisites](#prerequisites)
-  - [Concepts](#concepts)
-  - [Get credentials](#get-credentials)
-  - [Available components](#available-components)
-  - [Reference documentation](#reference-documentation)
-  - [Examples](#examples)
+- [Prerequisites](#prerequisites)
+- [Concepts](#concepts)
+- [Get credentials](#get-credentials)
+- [Installation](#installation)
+- [Development](#development)
+  - [Dependencies](#dependencies)
+    - [Download dependencies](#download-dependencies)
+  - [Build the SDK](#build-the-sdk)
+  - [Test the SDK](#test-the-sdk)
+  - [Test coverage](#test-coverage)
+  - [Generate documentation with TypeDoc](#generate-documentation-with-typedoc)
+  - [Use the bundle functionality](#use-the-bundle-functionality)
+- [Available components](#available-components)
+- [Reference documentation](#reference-documentation)
+- [Examples](#examples)
 
 ## Prerequisites
 
@@ -65,7 +73,7 @@ To use the Data SDK with pure JavaScript, inject the compiled bundles from the C
 <script src="https://unpkg.com/@here/olp-sdk-dataservice-write/bundle.umd.min.js"></script> 
 ```
 
-To learn how to use the Data SDK, see the <a href="https://github.com/heremaps/here-data-sdk-typescript/blob/master/docs/GettingStartedGuide.md" target="_blank">Getting Started Guide</a>, <a href="https://developer.here.com/documentation/sdk-typescript/dev_guide/index.html" target="blank">Developer Guide</a>, and <a href="https://developer.here.com/documentation/sdk-typescript/api_reference/index.html"  target="_blank">API Reference</a>.
+To learn how to use the Data SDK, see the <a href="https://developer.here.com/documentation/sdk-typescript/dev_guide/index.html" target="blank">Developer Guide</a> and <a href="https://developer.here.com/documentation/sdk-typescript/api_reference/index.html"  target="_blank">API Reference</a>.
 
 ## Development
 


### PR DESCRIPTION
Update documentation due to technical writing standards.

Moved the "Installation" section from README.md to GettingStartedGuide.md.
Moved the "Build the SDK" section from README.md to GettingStartedGuide.md.
Moved the "Why Use" topic to Introduction (in GitLab).
Added Table of Contents.
Changed outdated platform URLs to actual ones.

Relates-To: TECHDOCS-1228

Signed-off-by: Nataliia Plakhtii <ext-nataliia.plakhtii@here.com>