### PR TITLE
Fix return type for dataservice-api functions.

### DIFF
--- a/@here/olp-sdk-authentication/package.json
+++ b/@here/olp-sdk-authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-authentication",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "description": "Wrapper around the HERE Authentication and Authorization REST API obtaining short-lived access tokens that are used to authenticate requests to HERE services.",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,7 +49,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "^1.7.1",
+    "@here/olp-sdk-core": "^1.8.0",
     "@here/olp-sdk-fetch": "^1.9.0",
     "properties-reader": "^0.3.1"
   },

--- a/@here/olp-sdk-core/package.json
+++ b/@here/olp-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-core",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Core features of the HERE Data Platform",
   "main": "index.js",
   "browser": "index.web.js",
@@ -50,7 +50,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@here/olp-sdk-fetch": "^1.9.0",
-    "@here/olp-sdk-dataservice-api": "^1.12.2"
+    "@here/olp-sdk-dataservice-api": "^1.13.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.7",

--- a/@here/olp-sdk-dataservice-api/lib/artifact-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/artifact-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -341,7 +341,7 @@ export async function getArtifactUsingGET(
 export async function putArtifactFileUsingPUT(
     builder: RequestBuilder,
     params: { artifactHrn: string; fileName: string; file: string }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/artifact/{artifactHrn}/{fileName}"
         .replace("{artifactHrn}", UrlBuilder.toString(params["artifactHrn"]))
         .replace("{fileName}", UrlBuilder.toString(params["fileName"]));
@@ -358,7 +358,7 @@ export async function putArtifactFileUsingPUT(
         options.body = JSON.stringify(params["file"]);
     }
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**

--- a/@here/olp-sdk-dataservice-api/lib/blob-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/blob-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ export async function cancelMultipartUpload(
         multiPartToken: string;
         billingTag?: string;
     }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/data/{dataHandle}/multiparts/{multiPartToken}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{dataHandle}", UrlBuilder.toString(params["dataHandle"]))
@@ -225,7 +225,7 @@ export async function cancelMultipartUpload(
         headers
     };
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -284,7 +284,7 @@ export async function deleteBlob(
         dataHandle: string;
         billingTag?: string;
     }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/data/{dataHandle}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{dataHandle}", UrlBuilder.toString(params["dataHandle"]));
@@ -298,7 +298,7 @@ export async function deleteBlob(
         headers
     };
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**

--- a/@here/olp-sdk-dataservice-api/lib/index-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/index-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ export async function insertIndexes(
         indexes: Index[];
         layerID: string;
     }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerID}".replace(
         "{layerID}",
         UrlBuilder.toString(params["layerID"])
@@ -112,7 +112,7 @@ export async function insertIndexes(
         options.body = JSON.stringify(params["indexes"]);
     }
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -167,7 +167,7 @@ export async function performUpdate(
         layerID: string;
         request: UpdateIndexRequest;
     }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerID}".replace(
         "{layerID}",
         UrlBuilder.toString(params["layerID"])
@@ -185,5 +185,5 @@ export async function performUpdate(
         options.body = JSON.stringify(params["request"]);
     }
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }

--- a/@here/olp-sdk-dataservice-api/lib/volatile-blob-api.ts
+++ b/@here/olp-sdk-dataservice-api/lib/volatile-blob-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ export async function deleteVolatileBlob(
         dataHandle: string;
         billingTag?: string;
     }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/data/{dataHandle}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{dataHandle}", UrlBuilder.toString(params["dataHandle"]));
@@ -135,7 +135,7 @@ export async function deleteVolatileBlob(
         headers
     };
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }
 
 /**
@@ -191,7 +191,7 @@ export async function putVolatileBlob(
         body: string;
         billingTag?: string;
     }
-): Promise<any> {
+): Promise<Response> {
     const baseUrl = "/layers/{layerId}/data/{dataHandle}"
         .replace("{layerId}", UrlBuilder.toString(params["layerId"]))
         .replace("{dataHandle}", UrlBuilder.toString(params["dataHandle"]));
@@ -209,5 +209,5 @@ export async function putVolatileBlob(
         options.body = JSON.stringify(params["body"]);
     }
 
-    return builder.request<any>(urlBuilder, options);
+    return builder.requestBlob(urlBuilder, options);
 }

--- a/@here/olp-sdk-dataservice-api/package.json
+++ b/@here/olp-sdk-dataservice-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-api",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "description": "Generated from the OpenAPI specification of the HERE Open Location Platform Data API",
   "main": "index.js",
   "typings": "index",

--- a/@here/olp-sdk-dataservice-api/test/ArtifactApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/ArtifactApi.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ describe("ArtifactApi", function() {
         };
         const builder = {
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/artifact/mocked-artifactHrn/mocked-fileName"
                 );

--- a/@here/olp-sdk-dataservice-api/test/BlobApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/BlobApi.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ describe("BlobApi", function() {
         };
         const builder = {
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/layers/mocked-id/data/mocked-datahandle/multiparts/mocked-multiPartToken?billingTag=mocked-billingTag"
                 );
@@ -122,7 +122,7 @@ describe("BlobApi", function() {
         };
         const builder = {
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/layers/mocked-id/data/mocked-datahandle?billingTag=mocked-billingTag"
                 );

--- a/@here/olp-sdk-dataservice-api/test/IndexApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/IndexApi.test.ts
@@ -65,4 +65,49 @@ describe("IndexApi", function() {
         assert.equal(response.data && response.data.length, 2);
         expect(response).to.be.equal(mockedResponse);
     });
+
+    it("Should performUpdate provide data", async function() {
+        const params = {
+            layerID: "mocked-id",
+            request: {}
+        };
+        const builder = {
+            baseUrl: "http://mocked.url",
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
+                expect(urlBuilder.url).to.be.equal(
+                    "http://mocked.url/layers/mocked-id"
+                );
+                expect(options.method).to.be.equal("PUT");
+                return Promise.resolve("success");
+            }
+        };
+        const result = await IndexApi.performUpdate(
+            (builder as unknown) as RequestBuilder,
+            params
+        );
+        expect(result).to.be.equal("success");
+    });
+
+    it("Should insertIndexes provide data", async function() {
+        const params = {
+            layerID: "mocked-id",
+            indexes: [{ id: "test-index" }]
+        };
+        const builder = {
+            baseUrl: "http://mocked.url",
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
+                expect(urlBuilder.url).to.be.equal(
+                    "http://mocked.url/layers/mocked-id"
+                );
+                expect(options.method).to.be.equal("POST");
+                expect(options.body).equals(JSON.stringify(params.indexes));
+                return Promise.resolve("success");
+            }
+        };
+        const result = await IndexApi.insertIndexes(
+            (builder as unknown) as RequestBuilder,
+            params
+        );
+        expect(result).to.be.equal("success");
+    });
 });

--- a/@here/olp-sdk-dataservice-api/test/VolatileBlobApi.test.ts
+++ b/@here/olp-sdk-dataservice-api/test/VolatileBlobApi.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2022 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ describe("VolatileBlobApi", function() {
         };
         const builder = {
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/layers/mocked-id/data/mocked-datahandle?billingTag=mocked-billingTag"
                 );
@@ -110,7 +110,7 @@ describe("VolatileBlobApi", function() {
         };
         const builder = {
             baseUrl: "http://mocked.url",
-            request: async (urlBuilder: UrlBuilder, options: any) => {
+            requestBlob: async (urlBuilder: UrlBuilder, options: any) => {
                 expect(urlBuilder.url).to.be.equal(
                     "http://mocked.url/layers/mocked-id/data/mocked-datahandle?billingTag=mocked-billingTag"
                 );

--- a/@here/olp-sdk-dataservice-read/package.json
+++ b/@here/olp-sdk-dataservice-read/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-read",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "description": "Wrapper around a subset of the HERE Open Location Platform Data REST API related to reading data from OLP catalogs",
   "main": "index.js",
   "browser": "index.web.js",
@@ -49,8 +49,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "^1.7.1",
-    "@here/olp-sdk-dataservice-api": "^1.12.2",
+    "@here/olp-sdk-core": "^1.8.0",
+    "@here/olp-sdk-dataservice-api": "^1.13.0",
     "@here/olp-sdk-fetch": "^1.9.0"
   },
   "devDependencies": {

--- a/@here/olp-sdk-dataservice-write/package.json
+++ b/@here/olp-sdk-dataservice-write/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-dataservice-write",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Wrapper around a subset of the HERE Open Location Platform Data REST API related to writing data to OLP catalogs",
   "main": "index.js",
   "browser": "index.web.js",
@@ -50,8 +50,8 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@here/olp-sdk-core": "^1.7.1",
-    "@here/olp-sdk-dataservice-api": "^1.12.2",
+    "@here/olp-sdk-core": "^1.8.0",
+    "@here/olp-sdk-dataservice-api": "^1.13.0",
     "@here/olp-sdk-fetch": "^1.9.0"
   },
   "devDependencies": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v1.13.0 (02/09/2022)
+
+**olp-sdk-dataservice-api**
+
+- Updated the return type `any` => `Response` for functions:
+
+`ArtifactsApi::putArtifactFileUsingPUT`,
+
+`BlobApi::cancelMultipartUpload`,
+
+`BlobApi::deleteBlob`,
+
+`IndexApi::insertIndexes`,
+
+`IndexApi::performUpdate`,
+
+`VolatileBlobApi::deleteVolatileBlob`,
+
+`VolatileBlobApi::putVolatileBlob`.
+
+
 ## v1.12.2 (11/01/2022)
 
 **olp-sdk-dataservice-read**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/olp-sdk-ts",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "description": "HERE OLP SDK for TypeScript",
   "author": {
     "name": "HERE Europe B.V.",


### PR DESCRIPTION
Updated the return type `any` => `Response` for functions:

`ArtifactsApi::putArtifactFileUsingPUT`,

`BlobApi::cancelMultipartUpload`,

`BlobApi::deleteBlob`,

`IndexApi::insertIndexes`,

`IndexApi::performUpdate`,

`VolatileBlobApi::deleteVolatileBlob`,

`VolatileBlobApi::putVolatileBlob`.

Updated CHANGLOG.ms and versions.

Relates-To: OLPSUP-19972

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>