### PR TITLE
Fix Build Status URL in Readme

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
 					<tbody><tr>
 							<td align="left">Build/Test/Bundling/Typedoc</td>
 							<td align="left">Node 16.13.2 (LTS)</td>
-							<td align="left"><a href="https://app.travis-ci.com/heremaps/here-data-sdk-typescript" target="_blank"><img src="https://app.travis-ci.com/heremaps/here-data-sdk-typescript.svg?branch=master" alt="Build Status"></a></td>
+							<td align="left"><a href="https://github.com/heremaps/here-data-sdk-typescript/actions/workflows/ci.yml" target="_blank"><img src="https://github.com/heremaps/here-data-sdk-typescript/actions/workflows/ci.yml/badge.svg" alt="Build Status"></a></td>
 						</tr>
 				</tbody></table>
 				<a href="#test-coverage" id="test-coverage" style="color: inherit; text-decoration: none;">


### PR DESCRIPTION
Replace deprecated Travis badge URL to Github Pages URL.

Relates-To: TECHDOCS-2921