### PR TITLE
TW-1242: update links and touch up "Get started"

### DIFF
--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -1,35 +1,15 @@
 # Get started
 
-HERE Data SDK for TypeScript includes the core components to access the HERE APIs from any web-based application.
-
-In this guide, learn how to authenticate to and start working with the HERE platform using the Data SDK:
-
-- [Prerequisites](#prerequisites)
-- [Concepts](#concepts)
-- [Get credentials](#get-credentials)
-- [Installation](#installation)
-- [Development](#development)
-  - [Dependencies](#dependencies)
-    - [Download dependencies](#download-dependencies)
-  - [Build the SDK](#build-the-sdk)
-  - [Test the SDK](#test-the-sdk)
-  - [Test coverage](#test-coverage)
-  - [Generate documentation with TypeDoc](#generate-documentation-with-typedoc)
-  - [Use the bundle functionality](#use-the-bundle-functionality)
-- [Available components](#available-components)
-- [Reference documentation](#reference-documentation)
-- [Examples](#examples)
+HERE Data SDK for TypeScript includes the core components to access HERE APIs from any web-based application.
+Read this topic to learn how to authenticate to and start working with the HERE platform using the HERE Data SDK for TypeScript.
 
 ## Prerequisites
 
-To start using Data SDK for TypeScript, you need a platform user account.
+- HERE platform account. Follow [this link](https://platform.here.com/portal/sign-up) to create an account. 
+- Basic understanding of the core HERE platform concepts.
+- Basic TypeScript proficiency.
 
-Working with the Data SDK requires knowledge of the following subjects:
-
-- Basic understanding of the core [HERE platform concepts](#concepts).
-- Basic proficiency with TypeScript.
-
-## Concepts
+### Concepts
 
 To use Data SDK for TypeScript, you need to understand the following concepts related to the HERE platform:
 
@@ -37,8 +17,6 @@ To use Data SDK for TypeScript, you need to understand the following concepts re
 * [Layers](https://www.here.com/docs/bundle/data-api-developer-guide/page/rest/layers.html)
 * [Partitions](https://www.here.com/docs/bundle/data-api-developer-guide/page/rest/partitions.html)
 * [HERE Resource Names (HRNs)](https://www.here.com/docs/bundle/data-api-developer-guide/page/rest/hrn.html)
-
-For more details, see the [Data User Guide](https://www.here.com/docs/bundle/data-api-developer-guide/page/README.html).
 
 ## Get credentials
 
@@ -84,7 +62,8 @@ Data SDK for TypeScript has the following dependencies:
 - npm 10+ (for installation instructions, see <a href="https://www.npmjs.com/" target="_blank">npm</a>)
 - Node.js 18+ (for installation instructions, see <a href="http://nodejs.org" target="_blank">Node.js</a>)
 
-> **Note:** As an alternative to npm, you can also use Yarn 1+ (for installation instructions, see <a href="http://yarnpkg.com" target="_blank">Yarn</a>).
+> #### Note 
+> As an alternative to npm, you can use Yarn. For installation instructions, see [Yarn documentation](https://yarnpkg.com/getting-started/install).
 
 #### Download dependencies
 

--- a/docs/read-from-stream-layer.md
+++ b/docs/read-from-stream-layer.md
@@ -4,7 +4,7 @@ This example shows how to read partition metadata and partition data from a stre
 
 ## Build and run an app on Node.js
 
-Before you build an app, make sure that you installed all of the <a href="https://github.com/heremaps/here-data-sdk-typescript#dependencies" target="_blank">dependencies</a>.
+Before you build an app, make sure that you installed all of the [dependencies](GettingStartedGuide.md#dependencies).
 
 **To build and run an app on Node.js:**
 
@@ -65,7 +65,7 @@ App works!
 
 ## Create `StreamLayerClient`
 
-You can use the `StreamLayerClient` class to request data from the queue that streams data from a [stream layer](https://www.here.com/docs/bundle/data-api-developer-guide/page/README.html#stream-layers). Once a consumer reads the data, the data is no longer available to that consumer, but the data remains available to other consumers.
+You can use the `StreamLayerClient` class to request data from the queue that streams data from a [stream layer](https://www.here.com/docs/bundle/data-api-developer-guide/page/rest/layers.html#stream-layers). Once a consumer reads the data, the data is no longer available to that consumer, but the data remains available to other consumers.
 
 Stream layers can be configured with retention time, or time-to-live (TTL) which results in unconsumed data being removed after a specified period.
 
@@ -119,9 +119,9 @@ Stream layers can be configured with retention time, or time-to-live (TTL) which
 
 Now, to get data, you can call the `Poll` method.
 
-## <a name="get-data-streamlayerclient"></a>Get data and partition metadata from a stream layer
+## Get data and partition metadata from a stream layer
 
-You can read messages from a [stream layer](https://www.here.com/docs/bundle/data-api-developer-guide/page/README.html#stream-layers) if you subscribe to the layer. The messages contain data and the following partition metadata:
+You can read messages from a [stream layer](https://www.here.com/docs/bundle/data-api-developer-guide/page/rest/layers.html#stream-layers) if you subscribe to the layer. The messages contain data and the following partition metadata:
 
 - Data handle
 - ID
@@ -134,9 +134,9 @@ You can read messages from a [stream layer](https://www.here.com/docs/bundle/dat
 
 1. Create the `streamLayerClient` object.
 
-   For instructions, see [Create StreamLayerClient]([#create-streamlayerclient](https://www.here.com/docs/bundle/data-api-developer-guide/page/rest/layer-creating_2.html)).
+   For instructions, see [Create StreamLayerClient](#create-streamlayerclient).
 
-2. Subscribe to the stream layer. See [Subscribe to the stream layer](https://www.here.com/docs/bundle/data-api-developer-guide/page/rest/getting-data-stream.html)
+2. Subscribe to the stream layer.
 
 3. Call the `poll` method with the subscription ID.
 
@@ -197,7 +197,7 @@ You can read messages from a [stream layer](https://www.here.com/docs/bundle/dat
 
 You get data from the requested partition.
  
-## <a name="seek-streamlayerclient"></a>Seek to a predefined offset
+## Seek to a predefined offset
 
 You can start reading data from a specified offset. To start message consumption from a layer (topic) offset, move the message pointer to it. Once you seek to an offset, you cannot return to the initial offset, unless the initial offset is saved.
 
@@ -210,7 +210,7 @@ await streamLayerClient.seek(
 );
 ```
 
-## <a name="unsubscribe-streamlayerclient"></a>Delete a subscription to a layer
+## Delete a subscription to a layer
 
 You can delete a subscription to a layer (topic). This operation removes the subscription from the service.
 


### PR DESCRIPTION
This MR fixes several issues introduced when updating links from developer.here.com to their here.com/docs counterparts. In the process, the "Get started" documentation was touched up.

Resolves: TW-1242

Signed-off-by: Tom Papiernik <tomasz.papiernik@here.com>