### PR TITLE
Add method to read all the keys stored in cache

### DIFF
--- a/@here/olp-sdk-core/lib/cache/LRUCache.ts
+++ b/@here/olp-sdk-core/lib/cache/LRUCache.ts
@@ -194,6 +194,13 @@ export class LRUCache<Key, Value> {
         this.promoteEntry(entry);
         return entry.value;
     }
+ 
+    /**
+     * @returns List of all the keys stored in the cache
+     */
+    getAllKeys(): MapIterator<Key> {
+        return this.map.keys()
+    }
 
     /**
      * Clears the cache and removes all stored key-value pairs.


### PR DESCRIPTION
This MR will provide user the provision to fetch all the keys stored in cache at once with the method `getAllKeys()`.