### PR TITLE
Prepare the deploy workflow for npm OIDC publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,10 @@ on:
         - write
         - verify
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   deploy-sdk-package-to-npm:
     name: Typescript SDK Build and Deploy
@@ -31,7 +35,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: '24'
-          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
       # MockServer, which backs the functional tests, ships Java 17 bytecode.
       # The runner defaults to Java 11, so pin the version the jar needs.
       - name: Use Java
@@ -45,4 +50,3 @@ jobs:
         run: scripts/publish-packages.sh -${PACKAGE_NAME}
         env:
           PACKAGE_NAME: ${{ inputs.chooseDeploy }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -20,8 +20,6 @@
 # Simple script that bundles the publishing of packages,
 # to be run from GitHub Actions
 
-echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
-
 npm ci
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
npm trusted publishing needs the workflow to be able to mint an OIDC token, so grant `id-token: write` and narrow the rest of the job to `contents: read`.

`cache: npm` is gone from a release build: a restored dependency cache is state carried over from an earlier run, and what gets published should come from a clean install only. `package-manager-cache: false`

Relates-To: MINOR